### PR TITLE
feat: add persistent local repo clone

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -15,6 +15,8 @@ Auto-generated from all feature plans. Last updated: 2026-02-15
 - Docker container labels for stack metadata; in-memory desired-state store (006-scheduled-stack-updates)
 - TypeScript 5.9, Vue 3.5 (Composition API) + Naive UI 2.43 (component library), Pinia 2.2 (state management), Vue Router 4.5 (007-stack-ui-enhancements)
 - N/A (frontend only, uses existing backend API) (007-stack-ui-enhancements)
+- Go 1.26.0 + gin (HTTP), go-git (Git access), Docker CLI via CommandRunner, testcontainers-go (integration) (008-local-git-clone)
+- Filesystem-backed Git clone in a Docker volume; in-memory desired-state store (008-local-git-clone)
 
 - Go 1.22 + Go standard library (`net/http`, `os/exec`) (001-skeleton-runtime)
 
@@ -34,9 +36,9 @@ tests/
 Go 1.22: Follow standard conventions
 
 ## Recent Changes
+- 008-local-git-clone: Added Go 1.26.0 + gin (HTTP), go-git (Git access), Docker CLI via CommandRunner, testcontainers-go (integration)
 - 007-stack-ui-enhancements: Added TypeScript 5.9, Vue 3.5 (Composition API) + Naive UI 2.43 (component library), Pinia 2.2 (state management), Vue Router 4.5
 - 006-scheduled-stack-updates: Added Go 1.26.0 + gin (HTTP), go-git (Git access), Docker CLI via CommandRunner abstraction
-- 005-web-frontend: Added Go 1.25.7 (backend), Node.js 20 LTS (frontend build/runtime) + Gin (backend), Vue 3 + Vite + Naive UI + Pinia + Vue Router (frontend)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ export GIT_REVISION="main"
 docker compose up --build
 ```
 
+### Local Clone Volume
+
+The service stores a local working copy of the repository at a fixed path inside
+the container: `/repo`. Ensure your compose files mount a persistent volume at
+that path so refresh, reconciliation, and updates can use the local clone.
+
+If a refresh fails, the last successful clone is kept, but reconciliation and
+updates are blocked until the next successful refresh. The UI surfaces this as
+`updatesBlocked` in refresh status.
+
 - Backend API: <http://localhost:8080>
 - Frontend UI: <http://localhost:8081>
 

--- a/backend/cmd/docker-cd/main.go
+++ b/backend/cmd/docker-cd/main.go
@@ -86,7 +86,8 @@ func main() {
 	store := desiredstate.NewStore()
 	broadcaster := desiredstate.NewBroadcaster()
 	queue := refresh.NewQueue()
-	composeReader := &gitval.GoGitComposeReader{}
+	localClone := gitval.NewLocalClone(gitval.DefaultLocalRepoPath, cfg.GitRepoURL, cfg.GitAccessToken, cfg.GitRevision)
+	composeReader := gitval.NewLocalComposeReader(localClone)
 	refreshSvc := refresh.NewService(cfg, store, queue, composeReader)
 	refreshSvc.SetBroadcaster(broadcaster)
 
@@ -128,6 +129,12 @@ func main() {
 		logger.Error("scheduler initialization failed", "error", err)
 		os.Exit(1)
 	}
+
+	refreshSvc.SetCancelFuncs(reconciler.CancelActive, func() {
+		if schedulerSvc != nil {
+			schedulerSvc.CancelActiveUpdate()
+		}
+	})
 
 	// Create context with signal handling for graceful shutdown
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)

--- a/backend/internal/desiredstate/state.go
+++ b/backend/internal/desiredstate/state.go
@@ -61,14 +61,17 @@ type StackRecord struct {
 
 // Snapshot represents the latest desired state loaded from Git.
 type Snapshot struct {
-	Revision      string        `json:"revision"`
-	CommitMessage string        `json:"commitMessage,omitempty"`
-	Ref           string        `json:"ref"`
-	RefType       string        `json:"refType"`
-	RefreshedAt   time.Time     `json:"refreshedAt"`
-	RefreshStatus RefreshStatus `json:"refreshStatus"`
-	RefreshError  string        `json:"refreshError,omitempty"`
-	Stacks        []StackRecord `json:"stacks"`
+	Revision       string        `json:"revision"`
+	CommitMessage  string        `json:"commitMessage,omitempty"`
+	Ref            string        `json:"ref"`
+	RefType        string        `json:"refType"`
+	RefreshedAt    time.Time     `json:"refreshedAt"`
+	RefreshStatus  RefreshStatus `json:"refreshStatus"`
+	RefreshError   string        `json:"refreshError,omitempty"`
+	UpdatesBlocked bool          `json:"updatesBlocked"`
+	BlockedReason  string        `json:"blockedReason,omitempty"`
+	LocalPath      string        `json:"localPath,omitempty"`
+	Stacks         []StackRecord `json:"stacks"`
 }
 
 // Store provides thread-safe access to the desired state snapshot.
@@ -119,6 +122,20 @@ func (s *Store) UpdateStatus(status RefreshStatus, refreshErr string) {
 	s.snapshot.RefreshError = refreshErr
 }
 
+// SetRefreshState updates refresh status alongside blocking metadata.
+func (s *Store) SetRefreshState(status RefreshStatus, refreshErr string, updatesBlocked bool, blockedReason, localPath string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.snapshot == nil {
+		s.snapshot = &Snapshot{}
+	}
+	s.snapshot.RefreshStatus = status
+	s.snapshot.RefreshError = refreshErr
+	s.snapshot.UpdatesBlocked = updatesBlocked
+	s.snapshot.BlockedReason = blockedReason
+	s.snapshot.LocalPath = localPath
+}
+
 // GetStacks returns a copy of the current stacks, or nil if no snapshot exists.
 func (s *Store) GetStacks() []StackRecord {
 	s.mu.RLock()
@@ -145,12 +162,15 @@ func (s *Store) GetRefreshStatus() *Snapshot {
 		return nil
 	}
 	return &Snapshot{
-		Revision:      s.snapshot.Revision,
-		CommitMessage: s.snapshot.CommitMessage,
-		Ref:           s.snapshot.Ref,
-		RefType:       s.snapshot.RefType,
-		RefreshedAt:   s.snapshot.RefreshedAt,
-		RefreshStatus: s.snapshot.RefreshStatus,
-		RefreshError:  s.snapshot.RefreshError,
+		Revision:       s.snapshot.Revision,
+		CommitMessage:  s.snapshot.CommitMessage,
+		Ref:            s.snapshot.Ref,
+		RefType:        s.snapshot.RefType,
+		RefreshedAt:    s.snapshot.RefreshedAt,
+		RefreshStatus:  s.snapshot.RefreshStatus,
+		RefreshError:   s.snapshot.RefreshError,
+		UpdatesBlocked: s.snapshot.UpdatesBlocked,
+		BlockedReason:  s.snapshot.BlockedReason,
+		LocalPath:      s.snapshot.LocalPath,
 	}
 }

--- a/backend/internal/docker/client_test.go
+++ b/backend/internal/docker/client_test.go
@@ -247,7 +247,7 @@ func TestPullImages_Success(t *testing.T) {
 	runner := &stubRunner{output: []byte("")}
 	client := docker.NewClient(runner, "/var/run/docker.sock")
 
-	err := client.PullImages(context.Background(), "myproject", "/path/to/compose.yml")
+	err := client.PullImages(context.Background(), "myproject", "/path/to/compose.yml", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -257,7 +257,7 @@ func TestPullImages_Error(t *testing.T) {
 	runner := &stubRunner{output: []byte("pull failed"), err: fmt.Errorf("exit status 1")}
 	client := docker.NewClient(runner, "/var/run/docker.sock")
 
-	err := client.PullImages(context.Background(), "myproject", "/path/to/compose.yml")
+	err := client.PullImages(context.Background(), "myproject", "/path/to/compose.yml", "")
 	if err == nil {
 		t.Fatal("expected error from pull failure, got nil")
 	}

--- a/backend/internal/docker/images.go
+++ b/backend/internal/docker/images.go
@@ -9,7 +9,7 @@ import (
 // ImageOperations defines operations for managing Docker images.
 type ImageOperations interface {
 	// PullImages pulls all images for a compose project
-	PullImages(ctx context.Context, projectName, composeFile string) error
+	PullImages(ctx context.Context, projectName, composeFile, workDir string) error
 
 	// PruneImages removes all unused and dangling images system-wide
 	PruneImages(ctx context.Context) (imagesRemoved int, spaceReclaimed string, err error)
@@ -20,11 +20,12 @@ type ImageOperations interface {
 
 // PullImages pulls all images defined in a compose file.
 // Uses "docker compose pull" to handle all images in the compose file.
-func (c *Client) PullImages(ctx context.Context, projectName, composeFile string) error {
-	args := append(HostArgs(c.Socket),
-		"compose", "-p", projectName,
-		"-f", composeFile,
-		"pull")
+func (c *Client) PullImages(ctx context.Context, projectName, composeFile, workDir string) error {
+	args := append(HostArgs(c.Socket), "compose", "-p", projectName)
+	if workDir != "" {
+		args = append(args, "--project-directory", workDir)
+	}
+	args = append(args, "-f", composeFile, "pull")
 
 	out, err := c.Runner.Run(ctx, "docker", args...)
 	if err != nil {

--- a/backend/internal/git/local_clone.go
+++ b/backend/internal/git/local_clone.go
@@ -9,7 +9,6 @@ import (
 
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 )
 
@@ -136,7 +135,7 @@ func (c *LocalClone) fetchRepo(ctx context.Context, repo *gogit.Repository) erro
 	opts := &gogit.FetchOptions{
 		RemoteName: "origin",
 		Force:      true,
-		Prune:      gogit.Prune,
+		Prune:      true,
 		Tags:       gogit.AllTags,
 	}
 	if c.Token != "" {

--- a/backend/internal/git/local_clone.go
+++ b/backend/internal/git/local_clone.go
@@ -1,0 +1,240 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+)
+
+const DefaultLocalRepoPath = "/repo"
+
+// LocalClone manages a persistent on-disk Git clone.
+type LocalClone struct {
+	mu       sync.Mutex
+	Path     string
+	RepoURL  string
+	Token    string
+	Revision string
+}
+
+// NewLocalClone creates a LocalClone manager for a fixed path.
+func NewLocalClone(path, repoURL, token, revision string) *LocalClone {
+	return &LocalClone{
+		Path:     path,
+		RepoURL:  repoURL,
+		Token:    token,
+		Revision: revision,
+	}
+}
+
+// LocalComposeReader implements ComposeReader using a LocalClone.
+type LocalComposeReader struct {
+	Clone *LocalClone
+}
+
+// NewLocalComposeReader returns a ComposeReader backed by a LocalClone.
+func NewLocalComposeReader(clone *LocalClone) *LocalComposeReader {
+	return &LocalComposeReader{Clone: clone}
+}
+
+// ReadComposeFiles refreshes the local clone and reads compose files from it.
+func (r *LocalComposeReader) ReadComposeFiles(ctx context.Context, _, _, _, deployDir string) ([]ComposeEntry, string, string, error) {
+	return r.Clone.ReadComposeFiles(ctx, deployDir)
+}
+
+// ReadComposeFiles refreshes the local clone and returns compose entries.
+func (c *LocalClone) ReadComposeFiles(ctx context.Context, deployDir string) ([]ComposeEntry, string, string, error) {
+	repo, hash, commitMessage, err := c.refreshRepo(ctx)
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	entries, err := readComposeEntries(repo, *hash, deployDir)
+	if err != nil {
+		return nil, "", "", err
+	}
+
+	return entries, hash.String(), commitMessage, nil
+}
+
+func (c *LocalClone) refreshRepo(ctx context.Context) (*gogit.Repository, *plumbing.Hash, string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	repo, err := gogit.PlainOpen(c.Path)
+	if err != nil {
+		if err == gogit.ErrRepositoryNotExists {
+			return c.cloneRepo(ctx)
+		}
+		return c.reclone(ctx, fmt.Errorf("open repo failed: %w", err))
+	}
+
+	if err := c.fetchRepo(ctx, repo); err != nil {
+		return c.reclone(ctx, err)
+	}
+
+	hash, err := c.resolveRevision(repo)
+	if err != nil {
+		return c.reclone(ctx, err)
+	}
+
+	if err := checkoutHash(repo, *hash); err != nil {
+		return c.reclone(ctx, err)
+	}
+
+	message, err := commitMessage(repo, *hash)
+	if err != nil {
+		return c.reclone(ctx, err)
+	}
+
+	return repo, hash, message, nil
+}
+
+func (c *LocalClone) cloneRepo(ctx context.Context) (*gogit.Repository, *plumbing.Hash, string, error) {
+	_ = os.RemoveAll(c.Path)
+
+	opts := &gogit.CloneOptions{
+		URL:           c.RepoURL,
+		ReferenceName: plumbing.NewBranchReferenceName(c.Revision),
+		SingleBranch:  true,
+	}
+	if c.Token != "" {
+		opts.Auth = &http.BasicAuth{Username: "x-access-token", Password: c.Token}
+	}
+
+	repo, err := gogit.PlainCloneContext(ctx, c.Path, false, opts)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("clone failed: %w", err)
+	}
+
+	hash, err := c.resolveRevision(repo)
+	if err != nil {
+		return nil, nil, "", err
+	}
+
+	message, err := commitMessage(repo, *hash)
+	if err != nil {
+		return nil, nil, "", err
+	}
+
+	return repo, hash, message, nil
+}
+
+func (c *LocalClone) reclone(ctx context.Context, err error) (*gogit.Repository, *plumbing.Hash, string, error) {
+	_ = os.RemoveAll(c.Path)
+	return c.cloneRepo(ctx)
+}
+
+func (c *LocalClone) fetchRepo(ctx context.Context, repo *gogit.Repository) error {
+	opts := &gogit.FetchOptions{
+		RemoteName: "origin",
+		Force:      true,
+		Prune:      gogit.Prune,
+		Tags:       gogit.AllTags,
+	}
+	if c.Token != "" {
+		opts.Auth = &http.BasicAuth{Username: "x-access-token", Password: c.Token}
+	}
+
+	if err := repo.FetchContext(ctx, opts); err != nil && err != gogit.NoErrAlreadyUpToDate {
+		return fmt.Errorf("fetch failed: %w", err)
+	}
+	return nil
+}
+
+func (c *LocalClone) resolveRevision(repo *gogit.Repository) (*plumbing.Hash, error) {
+	if c.Revision == "" {
+		ref, err := repo.Head()
+		if err != nil {
+			return nil, fmt.Errorf("head lookup failed: %w", err)
+		}
+		hash := ref.Hash()
+		return &hash, nil
+	}
+
+	rev := plumbing.Revision("refs/remotes/origin/" + c.Revision)
+	hash, err := repo.ResolveRevision(rev)
+	if err == nil {
+		return hash, nil
+	}
+
+	rev = plumbing.Revision(c.Revision)
+	hash, err = repo.ResolveRevision(rev)
+	if err != nil {
+		return nil, fmt.Errorf("resolve revision failed: %w", err)
+	}
+	return hash, nil
+}
+
+func checkoutHash(repo *gogit.Repository, hash plumbing.Hash) error {
+	wt, err := repo.Worktree()
+	if err != nil {
+		return fmt.Errorf("worktree access failed: %w", err)
+	}
+
+	if err := wt.Checkout(&gogit.CheckoutOptions{Hash: hash, Force: true}); err != nil {
+		return fmt.Errorf("checkout failed: %w", err)
+	}
+	return nil
+}
+
+func commitMessage(repo *gogit.Repository, hash plumbing.Hash) (string, error) {
+	commit, err := repo.CommitObject(hash)
+	if err != nil {
+		return "", fmt.Errorf("commit lookup failed: %w", err)
+	}
+	return strings.TrimSpace(commit.Message), nil
+}
+
+func readComposeEntries(repo *gogit.Repository, hash plumbing.Hash, deployDir string) ([]ComposeEntry, error) {
+	commit, err := repo.CommitObject(hash)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get commit: %w", err)
+	}
+
+	rootTree, err := commit.Tree()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get tree: %w", err)
+	}
+
+	tree := rootTree
+	if deployDir != "" {
+		deployDir = strings.Trim(deployDir, "/")
+		tree, err = rootTree.Tree(deployDir)
+		if err != nil {
+			return nil, fmt.Errorf("deploy dir %q not found: %w", deployDir, err)
+		}
+	}
+
+	var entries []ComposeEntry
+	for _, entry := range tree.Entries {
+		if entry.Mode.IsFile() {
+			continue
+		}
+
+		subtree, err := tree.Tree(entry.Name)
+		if err != nil {
+			continue
+		}
+
+		composeFile, content, err := findComposeFile(subtree)
+		if err != nil || composeFile == "" {
+			continue
+		}
+
+		entries = append(entries, ComposeEntry{
+			StackPath:   entry.Name,
+			ComposeFile: composeFile,
+			Content:     content,
+		})
+	}
+
+	return entries, nil
+}

--- a/backend/internal/git/local_clone_test.go
+++ b/backend/internal/git/local_clone_test.go
@@ -1,0 +1,157 @@
+package git
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+func TestLocalClone_ReadComposeFiles_CloneAndRefresh(t *testing.T) {
+	remoteDir := t.TempDir()
+	revision, firstHash := initTestRepo(t, remoteDir, "stack-a", "docker-compose.yml", "services:\n  web:\n    image: nginx:alpine\n")
+
+	localDir := t.TempDir()
+	clone := NewLocalClone(filepath.Join(localDir, "repo"), remoteDir, "", revision)
+	reader := NewLocalComposeReader(clone)
+
+	entries, commitHash, _, err := reader.ReadComposeFiles(context.Background(), "", "", "", "")
+	if err != nil {
+		t.Fatalf("ReadComposeFiles failed: %v", err)
+	}
+	if commitHash != firstHash {
+		t.Fatalf("expected commit hash %s, got %s", firstHash, commitHash)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].StackPath != "stack-a" {
+		t.Fatalf("expected stack path stack-a, got %s", entries[0].StackPath)
+	}
+
+	secondHash := addCommit(t, remoteDir, "stack-a", "docker-compose.yml", "services:\n  web:\n    image: nginx:1.25-alpine\n")
+
+	entries, commitHash, _, err = reader.ReadComposeFiles(context.Background(), "", "", "", "")
+	if err != nil {
+		t.Fatalf("ReadComposeFiles refresh failed: %v", err)
+	}
+	if commitHash != secondHash {
+		t.Fatalf("expected updated hash %s, got %s", secondHash, commitHash)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry after refresh, got %d", len(entries))
+	}
+}
+
+func TestLocalClone_RecloneOnMissingRepo(t *testing.T) {
+	remoteDir := t.TempDir()
+	revision, _ := initTestRepo(t, remoteDir, "stack-a", "docker-compose.yml", "services:\n  web:\n    image: nginx:alpine\n")
+
+	localDir := filepath.Join(t.TempDir(), "repo")
+	clone := NewLocalClone(localDir, remoteDir, "", revision)
+	reader := NewLocalComposeReader(clone)
+
+	if _, _, _, err := reader.ReadComposeFiles(context.Background(), "", "", "", ""); err != nil {
+		t.Fatalf("initial ReadComposeFiles failed: %v", err)
+	}
+
+	if err := os.RemoveAll(localDir); err != nil {
+		t.Fatalf("failed to remove local clone: %v", err)
+	}
+
+	if _, _, _, err := reader.ReadComposeFiles(context.Background(), "", "", "", ""); err != nil {
+		t.Fatalf("reclone ReadComposeFiles failed: %v", err)
+	}
+}
+
+func TestLocalClone_RecloneOnCorruptRepo(t *testing.T) {
+	remoteDir := t.TempDir()
+	revision, _ := initTestRepo(t, remoteDir, "stack-a", "docker-compose.yml", "services:\n  web:\n    image: nginx:alpine\n")
+
+	localDir := filepath.Join(t.TempDir(), "repo")
+	clone := NewLocalClone(localDir, remoteDir, "", revision)
+	reader := NewLocalComposeReader(clone)
+
+	if _, _, _, err := reader.ReadComposeFiles(context.Background(), "", "", "", ""); err != nil {
+		t.Fatalf("initial ReadComposeFiles failed: %v", err)
+	}
+
+	if err := os.RemoveAll(localDir); err != nil {
+		t.Fatalf("failed to remove local clone: %v", err)
+	}
+	if err := os.WriteFile(localDir, []byte("corrupt"), 0644); err != nil {
+		t.Fatalf("failed to corrupt local clone: %v", err)
+	}
+
+	if _, _, _, err := reader.ReadComposeFiles(context.Background(), "", "", "", ""); err != nil {
+		t.Fatalf("reclone after corruption failed: %v", err)
+	}
+}
+
+func initTestRepo(t *testing.T, dir, stack, composeFile, content string) (string, string) {
+	repo, err := gogit.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("PlainInit failed: %v", err)
+	}
+
+	revision := "master"
+	if err := writeComposeFile(dir, stack, composeFile, content); err != nil {
+		t.Fatalf("writeComposeFile failed: %v", err)
+	}
+
+	hash := commitAll(t, repo, "initial")
+	if err := repo.Storer.SetReference(plumbing.NewHashReference(plumbing.NewBranchReferenceName(revision), hash)); err != nil {
+		t.Fatalf("set reference failed: %v", err)
+	}
+
+	return revision, hash.String()
+}
+
+func addCommit(t *testing.T, repoPath, stack, composeFile, content string) string {
+	repo, err := gogit.PlainOpen(repoPath)
+	if err != nil {
+		t.Fatalf("PlainOpen failed: %v", err)
+	}
+	if err := writeComposeFile(repoPath, stack, composeFile, content); err != nil {
+		t.Fatalf("writeComposeFile failed: %v", err)
+	}
+
+	hash := commitAll(t, repo, "update")
+	return hash.String()
+}
+
+func writeComposeFile(repoPath, stack, composeFile, content string) error {
+	stackDir := filepath.Join(repoPath, stack)
+	if err := os.MkdirAll(stackDir, 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(stackDir, composeFile), []byte(content), 0644)
+}
+
+func commitAll(t *testing.T, repo *gogit.Repository, message string) plumbing.Hash {
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("Worktree failed: %v", err)
+	}
+	if _, err := wt.Add("."); err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+	hash, err := wt.Commit(message, &gogit.CommitOptions{Author: testAuthor()})
+	if err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+	return hash
+}
+
+func testAuthor() *object.Signature {
+	return &object.Signature{
+		Name:  "Test",
+		Email: "test@example.com",
+		When:  time.Now(),
+	}
+}

--- a/backend/internal/http/handler.go
+++ b/backend/internal/http/handler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lucasreiners/docker-cd/internal/config"
 	"github.com/lucasreiners/docker-cd/internal/desiredstate"
 	"github.com/lucasreiners/docker-cd/internal/docker"
+	"github.com/lucasreiners/docker-cd/internal/git"
 	"github.com/lucasreiners/docker-cd/internal/reconcile"
 	"github.com/lucasreiners/docker-cd/internal/refresh"
 	"github.com/lucasreiners/docker-cd/internal/render"
@@ -167,7 +168,10 @@ func RefreshStatusHandler(store *desiredstate.Store) gin.HandlerFunc {
 		snap := store.GetRefreshStatus()
 		if snap == nil {
 			snap = &desiredstate.Snapshot{
-				RefreshStatus: desiredstate.RefreshStatusQueued,
+				RefreshStatus:  desiredstate.RefreshStatusQueued,
+				UpdatesBlocked: true,
+				BlockedReason:  "refresh pending",
+				LocalPath:      git.DefaultLocalRepoPath,
 			}
 		}
 		c.JSON(http.StatusOK, snap)

--- a/backend/internal/reconcile/reconcile.go
+++ b/backend/internal/reconcile/reconcile.go
@@ -100,9 +100,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) []ReconciliationRun {
 	r.cancelMu.Unlock()
 	defer func() {
 		r.cancelMu.Lock()
-		if r.cancelActive == cancel {
-			r.cancelActive = nil
-		}
+		r.cancelActive = nil
 		r.cancelMu.Unlock()
 	}()
 

--- a/backend/internal/reconcile/reconcile.go
+++ b/backend/internal/reconcile/reconcile.go
@@ -54,6 +54,8 @@ type ReconciliationRun struct {
 // Reconciler compares desired state with runtime state and applies changes.
 type Reconciler struct {
 	mu            sync.Mutex
+	cancelMu      sync.Mutex
+	cancelActive  context.CancelFunc
 	store         *desiredstate.Store
 	policy        ReconciliationPolicy
 	compose       ComposeRunner
@@ -92,14 +94,36 @@ func (r *Reconciler) Reconcile(ctx context.Context) []ReconciliationRun {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	ctx, cancel := context.WithCancel(ctx)
+	r.cancelMu.Lock()
+	r.cancelActive = cancel
+	r.cancelMu.Unlock()
+	defer func() {
+		r.cancelMu.Lock()
+		if r.cancelActive == cancel {
+			r.cancelActive = nil
+		}
+		r.cancelMu.Unlock()
+	}()
+
 	if !r.policy.Enabled {
 		log.Printf("[info] reconciliation disabled, skipping")
+		return nil
+	}
+
+	refresh := r.store.GetRefreshStatus()
+	if refresh == nil || refresh.RefreshStatus != desiredstate.RefreshStatusCompleted || refresh.UpdatesBlocked {
+		log.Printf("[info] refresh not completed or updates blocked, skipping reconciliation")
 		return nil
 	}
 
 	snap := r.store.Get()
 	if snap == nil {
 		log.Printf("[info] no desired state available, skipping reconciliation")
+		return nil
+	}
+	if ctx.Err() != nil {
+		log.Printf("[info] reconciliation canceled before runtime inspection")
 		return nil
 	}
 
@@ -142,6 +166,10 @@ func (r *Reconciler) Reconcile(ctx context.Context) []ReconciliationRun {
 	var runs []ReconciliationRun
 
 	for _, drift := range drifts {
+		if ctx.Err() != nil {
+			log.Printf("[info] reconciliation canceled before applying changes")
+			return runs
+		}
 		if !drift.NeedSync && !drift.NeedRemove {
 			continue
 		}
@@ -168,6 +196,16 @@ func (r *Reconciler) Reconcile(ctx context.Context) []ReconciliationRun {
 	}
 
 	return runs
+}
+
+// CancelActive requests cancellation of a running reconciliation.
+func (r *Reconciler) CancelActive() {
+	r.cancelMu.Lock()
+	cancel := r.cancelActive
+	r.cancelMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
 }
 
 func (r *Reconciler) syncStack(ctx context.Context, drift DriftResult, snap *desiredstate.Snapshot) ReconciliationRun {

--- a/backend/internal/reconcile/reconcile_test.go
+++ b/backend/internal/reconcile/reconcile_test.go
@@ -472,7 +472,8 @@ func TestReconcile_ConcurrencyMutex(t *testing.T) {
 	store := desiredstate.NewStore()
 	composeContent := []byte("services:\n  web:\n    image: nginx\n")
 	store.Set(&desiredstate.Snapshot{
-		Revision: "rev1",
+		Revision:      "rev1",
+		RefreshStatus: desiredstate.RefreshStatusCompleted,
 		Stacks: []desiredstate.StackRecord{
 			{Path: "app1", ComposeFile: "docker-compose.yml", ComposeHash: "hash1", Status: desiredstate.StackSyncMissing, Content: composeContent},
 		},

--- a/backend/internal/reconcile/reconcile_test.go
+++ b/backend/internal/reconcile/reconcile_test.go
@@ -338,7 +338,8 @@ func TestReconcile_ComposeUpFailure(t *testing.T) {
 	store := desiredstate.NewStore()
 	composeContent := []byte("services:\n  web:\n    image: nginx\n")
 	store.Set(&desiredstate.Snapshot{
-		Revision: "rev1",
+		Revision:      "rev1",
+		RefreshStatus: desiredstate.RefreshStatusCompleted,
 		Stacks: []desiredstate.StackRecord{
 			{Path: "app1", ComposeFile: "docker-compose.yml", ComposeHash: "hash1", Status: desiredstate.StackSyncMissing, Content: composeContent},
 		},
@@ -379,7 +380,8 @@ func TestReconcile_DriftPolicy_Flag_NoAck(t *testing.T) {
 	store := desiredstate.NewStore()
 	composeContent := []byte("services:\n  web:\n    image: nginx\n")
 	store.Set(&desiredstate.Snapshot{
-		Revision: "rev1",
+		Revision:      "rev1",
+		RefreshStatus: desiredstate.RefreshStatusCompleted,
 		Stacks: []desiredstate.StackRecord{
 			{Path: "app1", ComposeFile: "docker-compose.yml", ComposeHash: "hash1", Status: desiredstate.StackSyncMissing, Content: composeContent},
 		},
@@ -407,7 +409,8 @@ func TestReconcile_DriftPolicy_Flag_WithAck(t *testing.T) {
 	store := desiredstate.NewStore()
 	composeContent := []byte("services:\n  web:\n    image: nginx\n")
 	store.Set(&desiredstate.Snapshot{
-		Revision: "rev1",
+		Revision:      "rev1",
+		RefreshStatus: desiredstate.RefreshStatusCompleted,
 		Stacks: []desiredstate.StackRecord{
 			{Path: "app1", ComposeFile: "docker-compose.yml", ComposeHash: "hash1", Status: desiredstate.StackSyncMissing, Content: composeContent},
 		},
@@ -441,7 +444,8 @@ func TestReconcile_DriftPolicy_Revert(t *testing.T) {
 	store := desiredstate.NewStore()
 	composeContent := []byte("services:\n  web:\n    image: nginx\n")
 	store.Set(&desiredstate.Snapshot{
-		Revision: "rev1",
+		Revision:      "rev1",
+		RefreshStatus: desiredstate.RefreshStatusCompleted,
 		Stacks: []desiredstate.StackRecord{
 			{Path: "app1", ComposeFile: "docker-compose.yml", ComposeHash: "hash1", Status: desiredstate.StackSyncMissing, Content: composeContent},
 		},
@@ -556,7 +560,8 @@ func TestReconciliationRun_Timestamps(t *testing.T) {
 	store := desiredstate.NewStore()
 	composeContent := []byte("services:\n  web:\n    image: nginx\n")
 	store.Set(&desiredstate.Snapshot{
-		Revision: "rev1",
+		Revision:      "rev1",
+		RefreshStatus: desiredstate.RefreshStatusCompleted,
 		Stacks: []desiredstate.StackRecord{
 			{Path: "app1", ComposeFile: "docker-compose.yml", ComposeHash: "hash1", Content: composeContent},
 		},
@@ -587,7 +592,8 @@ func TestReconcile_MultipleStacks_Sequential(t *testing.T) {
 	store := desiredstate.NewStore()
 	composeContent := []byte("services:\n  web:\n    image: nginx\n")
 	store.Set(&desiredstate.Snapshot{
-		Revision: "rev1",
+		Revision:      "rev1",
+		RefreshStatus: desiredstate.RefreshStatusCompleted,
 		Stacks: []desiredstate.StackRecord{
 			{Path: "app1", ComposeFile: "docker-compose.yml", ComposeHash: "h1", Content: composeContent},
 			{Path: "app2", ComposeFile: "docker-compose.yml", ComposeHash: "h2", Content: composeContent},
@@ -621,8 +627,9 @@ func TestReconcile_MultipleStacks_Sequential(t *testing.T) {
 func TestReconcile_RemoveStack(t *testing.T) {
 	store := desiredstate.NewStore()
 	store.Set(&desiredstate.Snapshot{
-		Revision: "rev1",
-		Stacks:   []desiredstate.StackRecord{},
+		Revision:      "rev1",
+		RefreshStatus: desiredstate.RefreshStatusCompleted,
+		Stacks:        []desiredstate.StackRecord{},
 	})
 
 	policy := reconcile.DefaultPolicy()

--- a/backend/internal/refresh/refresh.go
+++ b/backend/internal/refresh/refresh.go
@@ -21,6 +21,8 @@ type Service struct {
 	reader      git.ComposeReader
 	reconcileF  ReconcileFunc
 	broadcaster *desiredstate.Broadcaster
+	cancelRecon func()
+	cancelUpd   func()
 }
 
 // NewService creates a refresh service.
@@ -43,15 +45,18 @@ func (s *Service) SetReconcileFunc(f ReconcileFunc) {
 	s.reconcileF = f
 }
 
+// SetCancelFuncs sets optional callbacks to cancel running reconcile and update tasks.
+func (s *Service) SetCancelFuncs(cancelReconcile, cancelUpdate func()) {
+	s.cancelRecon = cancelReconcile
+	s.cancelUpd = cancelUpdate
+}
+
 // Start begins the refresh loop: listens for triggers from the queue and
 // performs refreshes. Also starts the periodic poll ticker if configured.
 // Blocks until ctx is cancelled.
 func (s *Service) Start(ctx context.Context) {
 	// Trigger initial startup refresh
-	s.queue.Enqueue(Trigger{
-		Source:      TriggerStartup,
-		RequestedAt: time.Now(),
-	})
+	s.enqueueRefresh(TriggerStartup)
 
 	// Start periodic polling if configured
 	if s.cfg.RefreshPollInterval > 0 {
@@ -71,6 +76,17 @@ func (s *Service) Start(ctx context.Context) {
 
 // RequestRefresh enqueues a refresh trigger and returns the queue result.
 func (s *Service) RequestRefresh(source TriggerSource) QueueResult {
+	return s.enqueueRefresh(source)
+}
+
+func (s *Service) enqueueRefresh(source TriggerSource) QueueResult {
+	if s.cancelRecon != nil {
+		s.cancelRecon()
+	}
+	if s.cancelUpd != nil {
+		s.cancelUpd()
+	}
+
 	return s.queue.Enqueue(Trigger{
 		Source:      source,
 		RequestedAt: time.Now(),
@@ -87,10 +103,7 @@ func (s *Service) pollLoop(ctx context.Context) {
 			return
 		case <-ticker.C:
 			log.Printf("[info] periodic refresh triggered (interval: %s)", s.cfg.RefreshPollInterval)
-			s.queue.Enqueue(Trigger{
-				Source:      TriggerPeriodic,
-				RequestedAt: time.Now(),
-			})
+			s.enqueueRefresh(TriggerPeriodic)
 		}
 	}
 }
@@ -98,7 +111,7 @@ func (s *Service) pollLoop(ctx context.Context) {
 func (s *Service) doRefresh(ctx context.Context, trigger Trigger) {
 	log.Printf("[info] starting refresh (source: %s)", trigger.Source)
 
-	s.store.UpdateStatus(desiredstate.RefreshStatusRefreshing, "")
+	s.store.SetRefreshState(desiredstate.RefreshStatusRefreshing, "", true, "refreshing", git.DefaultLocalRepoPath)
 	if s.broadcaster != nil {
 		s.broadcaster.PublishRefreshStatus(s.store.GetRefreshStatus())
 	}
@@ -113,7 +126,7 @@ func (s *Service) doRefresh(ctx context.Context, trigger Trigger) {
 
 	if err != nil {
 		log.Printf("[error] refresh failed: %v", err)
-		s.store.UpdateStatus(desiredstate.RefreshStatusFailed, err.Error())
+		s.store.SetRefreshState(desiredstate.RefreshStatusFailed, err.Error(), true, "refresh failed", git.DefaultLocalRepoPath)
 		if s.broadcaster != nil {
 			s.broadcaster.PublishRefreshStatus(s.store.GetRefreshStatus())
 		}
@@ -124,14 +137,17 @@ func (s *Service) doRefresh(ctx context.Context, trigger Trigger) {
 	newStacks := s.buildStacksPreservingStatus(entries)
 
 	snap := &desiredstate.Snapshot{
-		Revision:      commitHash,
-		CommitMessage: commitMessage,
-		Ref:           s.cfg.GitRevision,
-		RefType:       "branch",
-		RefreshedAt:   time.Now(),
-		RefreshStatus: desiredstate.RefreshStatusCompleted,
-		RefreshError:  "",
-		Stacks:        newStacks,
+		Revision:       commitHash,
+		CommitMessage:  commitMessage,
+		Ref:            s.cfg.GitRevision,
+		RefType:        "branch",
+		RefreshedAt:    time.Now(),
+		RefreshStatus:  desiredstate.RefreshStatusCompleted,
+		RefreshError:   "",
+		UpdatesBlocked: false,
+		BlockedReason:  "",
+		LocalPath:      git.DefaultLocalRepoPath,
+		Stacks:         newStacks,
 	}
 
 	s.store.Set(snap)

--- a/backend/internal/scheduler/scheduler.go
+++ b/backend/internal/scheduler/scheduler.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/lucasreiners/docker-cd/internal/config"
 	"github.com/lucasreiners/docker-cd/internal/desiredstate"
 	"github.com/lucasreiners/docker-cd/internal/docker"
+	"github.com/lucasreiners/docker-cd/internal/git"
 	"github.com/lucasreiners/docker-cd/internal/reconcile"
 	"github.com/robfig/cron/v3"
 )
@@ -21,6 +24,7 @@ type SchedulerService struct {
 	logger       *slog.Logger
 	mu           sync.Mutex
 	activeUpdate *UpdateCycle
+	activeCancel context.CancelFunc
 	stopChan     chan struct{}
 	store        *desiredstate.Store
 	dockerClient *docker.Client
@@ -140,6 +144,10 @@ func (s *SchedulerService) TriggerUpdateCycle(ctx context.Context) error {
 		return fmt.Errorf("scheduler is disabled")
 	}
 
+	if ok, reason := s.refreshReady(); !ok {
+		return fmt.Errorf("updates blocked: %s", reason)
+	}
+
 	s.logger.Info("TriggerUpdateCycle called")
 
 	s.mu.Lock()
@@ -163,8 +171,11 @@ func (s *SchedulerService) TriggerUpdateCycle(ctx context.Context) error {
 		"cycle_id", cycle.CycleID,
 		"start_time", cycle.StartTime)
 
+	cycleCtx, cancel := context.WithCancel(ctx)
+	s.activeCancel = cancel
+
 	// Trigger update cycle in background
-	go s.executeUpdateCycleManual(ctx, cycle)
+	go s.executeUpdateCycleManual(cycleCtx, cycle)
 	return nil
 }
 
@@ -191,6 +202,10 @@ func (s *SchedulerService) GetUpdateStatus() interface{} {
 // runUpdateCycle executes a full update cycle (T013)
 // Used by cron scheduler - can terminate existing cycles
 func (s *SchedulerService) runUpdateCycle(ctx context.Context) {
+	if ok, reason := s.refreshReady(); !ok {
+		s.logger.Warn("update cycle skipped - refresh not ready", "reason", reason)
+		return
+	}
 	s.mu.Lock()
 	// Terminate existing cycle if running (FR-020)
 	if s.activeUpdate != nil {
@@ -201,7 +216,9 @@ func (s *SchedulerService) runUpdateCycle(ctx context.Context) {
 
 	// Create new update cycle
 	cycle := NewUpdateCycle()
+	cycleCtx, cancel := context.WithCancel(ctx)
 	s.activeUpdate = cycle
+	s.activeCancel = cancel
 	s.mu.Unlock()
 
 	defer func() {
@@ -215,7 +232,25 @@ func (s *SchedulerService) runUpdateCycle(ctx context.Context) {
 	}()
 
 	// Execute update cycle
-	s.executeUpdateCycle(ctx, cycle)
+	s.executeUpdateCycle(cycleCtx, cycle)
+}
+
+func (s *SchedulerService) refreshReady() (bool, string) {
+	if s.store == nil {
+		return false, "refresh status unavailable"
+	}
+	status := s.store.GetRefreshStatus()
+	if status == nil || status.RefreshStatus != desiredstate.RefreshStatusCompleted {
+		return false, "refresh not completed"
+	}
+	if status.UpdatesBlocked {
+		reason := status.BlockedReason
+		if reason == "" {
+			reason = "updates blocked"
+		}
+		return false, reason
+	}
+	return true, ""
 }
 
 // executeUpdateCycleManual executes an update cycle from manual trigger
@@ -229,6 +264,7 @@ func (s *SchedulerService) executeUpdateCycleManual(ctx context.Context, cycle *
 			"cycle_id", cycle.CycleID)
 		s.mu.Lock()
 		s.activeUpdate = nil
+		s.activeCancel = nil
 		s.mu.Unlock()
 		s.logger.Info("activeUpdate cleared",
 			"cycle_id", cycle.CycleID)
@@ -245,6 +281,10 @@ func (s *SchedulerService) executeUpdateCycleManual(ctx context.Context, cycle *
 
 // executeUpdateCycle performs the actual update operations (T013-T019)
 func (s *SchedulerService) executeUpdateCycle(ctx context.Context, cycle *UpdateCycle) {
+	if ctx.Err() != nil {
+		s.logger.Warn("update cycle canceled before start", "cycle_id", cycle.CycleID)
+		return
+	}
 	// Log cycle start (T018)
 	s.logger.Info("update cycle started",
 		"cycle_id", cycle.CycleID,
@@ -278,6 +318,10 @@ func (s *SchedulerService) executeUpdateCycle(ctx context.Context, cycle *Update
 
 	// Process each stack sequentially (T014, FR-016)
 	for i, stack := range snap.Stacks {
+		if ctx.Err() != nil {
+			s.logger.Warn("update cycle canceled", "cycle_id", cycle.CycleID)
+			return
+		}
 		// Skip if stack is in error state (FR-014, T019)
 		if stack.Status == desiredstate.StackSyncFailed {
 			s.logger.Warn("skipping stack in failed state",
@@ -386,6 +430,16 @@ func (s *SchedulerService) executeUpdateCycle(ctx context.Context, cycle *Update
 	}
 }
 
+// CancelActiveUpdate requests cancellation of a running update cycle.
+func (s *SchedulerService) CancelActiveUpdate() {
+	s.mu.Lock()
+	cancel := s.activeCancel
+	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
 // updateStack updates a single stack (T014-T016)
 func (s *SchedulerService) updateStack(ctx context.Context, stack desiredstate.StackRecord) StackUpdateResult {
 	result := StackUpdateResult{
@@ -399,8 +453,12 @@ func (s *SchedulerService) updateStack(ctx context.Context, stack desiredstate.S
 	// TODO: Get image digests before pull (T015)
 	// This would require parsing the compose file to get image names
 
+	deployDir := strings.Trim(s.config.GitDeployDir, "/")
+	stackDir := filepath.Join(git.DefaultLocalRepoPath, deployDir, stack.Path)
+	composePath := filepath.Join(stackDir, stack.ComposeFile)
+
 	// Pull images (T014)
-	err := s.dockerClient.PullImages(ctx, result.ProjectName, stack.ComposeFile)
+	err := s.dockerClient.PullImages(ctx, result.ProjectName, composePath, stackDir)
 	result.PullEndTime = time.Now()
 
 	if err != nil {

--- a/backend/internal/scheduler/scheduler_test.go
+++ b/backend/internal/scheduler/scheduler_test.go
@@ -220,6 +220,7 @@ func TestTriggerUpdateCycle_Success(t *testing.T) {
 	store := desiredstate.NewStore()
 	// Add a test stack
 	store.Set(&desiredstate.Snapshot{
+		RefreshStatus: desiredstate.RefreshStatusCompleted,
 		Stacks: []desiredstate.StackRecord{{
 			Path:        "test-stack",
 			ComposeFile: "/test/docker-compose.yml",
@@ -274,6 +275,7 @@ func TestTriggerUpdateCycle_AlreadyRunning(t *testing.T) {
 
 	store := desiredstate.NewStore()
 	store.Set(&desiredstate.Snapshot{
+		RefreshStatus: desiredstate.RefreshStatusCompleted,
 		Stacks: []desiredstate.StackRecord{{
 			Path:        "test-stack",
 			ComposeFile: "/test/docker-compose.yml",

--- a/backend/tests/integration/dind_reconcile_test.go
+++ b/backend/tests/integration/dind_reconcile_test.go
@@ -5,14 +5,22 @@ package integration_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/lucasreiners/docker-cd/internal/config"
 	"github.com/lucasreiners/docker-cd/internal/desiredstate"
 	"github.com/lucasreiners/docker-cd/internal/docker"
+	"github.com/lucasreiners/docker-cd/internal/git"
 	"github.com/lucasreiners/docker-cd/internal/reconcile"
+	"github.com/lucasreiners/docker-cd/internal/refresh"
 	"github.com/lucasreiners/docker-cd/tests/integration/dind"
 )
 
@@ -102,6 +110,157 @@ func TestDinD_ReconcileComposeUp(t *testing.T) {
 		t.Errorf("store status: got %q, want %q", snap.Stacks[0].Status, desiredstate.StackSyncSynced)
 	}
 	cleanupStack(t, runner, "myapp")
+}
+
+func TestDinD_ReconcileBlockedUntilRefreshComplete(t *testing.T) {
+	env := dind.StartT(t)
+	runner := &dindRunner{Host: env.DockerHost}
+
+	composeContent := []byte("services:\n  web:\n    image: nginx:alpine\n")
+	composeHash := desiredstate.ComposeHash(composeContent)
+
+	store := desiredstate.NewStore()
+	store.Set(&desiredstate.Snapshot{
+		Revision:       "rev1",
+		CommitMessage:  "blocked",
+		RefreshStatus:  desiredstate.RefreshStatusQueued,
+		UpdatesBlocked: true,
+		BlockedReason:  "refresh pending",
+		Stacks: []desiredstate.StackRecord{
+			{
+				Path:        "gatedapp",
+				ComposeFile: "docker-compose.yml",
+				ComposeHash: composeHash,
+				Status:      desiredstate.StackSyncMissing,
+				Content:     composeContent,
+			},
+		},
+	})
+
+	composeRunner := reconcile.NewDockerComposeRunner(runner, env.DockerHost)
+	client := docker.NewClient(runner, env.DockerHost)
+	inspector := reconcile.NewDockerContainerInspector(client)
+	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), composeRunner, inspector, reconcile.NewAckStore(), "")
+
+	runs := r.Reconcile(context.Background())
+	if len(runs) != 0 {
+		t.Fatalf("expected reconcile to be blocked, got %d runs", len(runs))
+	}
+
+	store.Set(&desiredstate.Snapshot{
+		Revision:       "rev1",
+		CommitMessage:  "unblocked",
+		RefreshStatus:  desiredstate.RefreshStatusCompleted,
+		UpdatesBlocked: false,
+		Stacks: []desiredstate.StackRecord{
+			{
+				Path:        "gatedapp",
+				ComposeFile: "docker-compose.yml",
+				ComposeHash: composeHash,
+				Status:      desiredstate.StackSyncMissing,
+				Content:     composeContent,
+			},
+		},
+	})
+
+	runs2 := r.Reconcile(context.Background())
+	if len(runs2) != 1 || runs2[0].Result != "success" {
+		t.Fatalf("expected reconcile to run after refresh, got %s", safeResult(runs2))
+	}
+	waitForContainers(t, runner, 1, 15*time.Second)
+	cleanupStack(t, runner, "gatedapp")
+}
+
+func TestLocalClone_ManualRefreshUpdatesSnapshot(t *testing.T) {
+	remoteDir := t.TempDir()
+	revision, firstHash := initLocalRepo(t, remoteDir, "stack-a", "docker-compose.yml", "services:\n  web:\n    image: nginx:alpine\n")
+
+	cloneDir := filepath.Join(t.TempDir(), "repo")
+	localClone := git.NewLocalClone(cloneDir, remoteDir, "", revision)
+	reader := git.NewLocalComposeReader(localClone)
+
+	store := desiredstate.NewStore()
+	queue := refresh.NewQueue()
+	cfg := config.Config{GitRepoURL: remoteDir, GitRevision: revision}
+	svc := refresh.NewService(cfg, store, queue, reader)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	go svc.Start(ctx)
+
+	waitForRevision(t, store, firstHash)
+
+	secondHash := addLocalCommit(t, remoteDir, "stack-a", "docker-compose.yml", "services:\n  web:\n    image: nginx:1.25-alpine\n")
+	_ = svc.RequestRefresh(refresh.TriggerManual)
+	waitForRevision(t, store, secondHash)
+}
+
+func TestLocalClone_RefreshFailureBlocksUpdates(t *testing.T) {
+	store := desiredstate.NewStore()
+	queue := refresh.NewQueue()
+	badClone := git.NewLocalClone(filepath.Join(t.TempDir(), "repo"), filepath.Join(t.TempDir(), "missing"), "", "main")
+	reader := git.NewLocalComposeReader(badClone)
+
+	cfg := config.Config{GitRepoURL: "missing", GitRevision: "main"}
+	svc := refresh.NewService(cfg, store, queue, reader)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	go svc.Start(ctx)
+
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for refresh failure")
+		default:
+			snap := store.Get()
+			if snap != nil && snap.RefreshStatus == desiredstate.RefreshStatusFailed {
+				if !snap.UpdatesBlocked {
+					t.Fatal("expected updatesBlocked to be true after refresh failure")
+				}
+				if snap.BlockedReason == "" {
+					t.Fatal("expected blockedReason to be set after refresh failure")
+				}
+				return
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+}
+
+func TestLocalClone_RefreshRecoversFromCorruption(t *testing.T) {
+	remoteDir := t.TempDir()
+	revision, firstHash := initLocalRepo(t, remoteDir, "stack-a", "docker-compose.yml", "services:\n  web:\n    image: nginx:alpine\n")
+
+	cloneDir := filepath.Join(t.TempDir(), "repo")
+	localClone := git.NewLocalClone(cloneDir, remoteDir, "", revision)
+	reader := git.NewLocalComposeReader(localClone)
+
+	store := desiredstate.NewStore()
+	queue := refresh.NewQueue()
+	cfg := config.Config{GitRepoURL: remoteDir, GitRevision: revision}
+	svc := refresh.NewService(cfg, store, queue, reader)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+
+	go svc.Start(ctx)
+
+	waitForRevision(t, store, firstHash)
+
+	if err := os.RemoveAll(cloneDir); err != nil {
+		t.Fatalf("failed to remove local clone: %v", err)
+	}
+	if err := os.WriteFile(cloneDir, []byte("corrupt"), 0644); err != nil {
+		t.Fatalf("failed to corrupt local clone: %v", err)
+	}
+
+	secondHash := addLocalCommit(t, remoteDir, "stack-a", "docker-compose.yml", "services:\n  web:\n    image: nginx:1.25-alpine\n")
+	_ = svc.RequestRefresh(refresh.TriggerManual)
+	waitForRevision(t, store, secondHash)
 }
 
 func TestDinD_ReconcileNoOpWhenInSync(t *testing.T) {
@@ -544,4 +703,84 @@ func safeResult(runs []reconcile.ReconciliationRun) string {
 		parts[i] = fmt.Sprintf("stack=%s result=%s error=%s", run.StackPath, run.Result, run.Error)
 	}
 	return strings.Join(parts, "; ")
+}
+
+func initLocalRepo(t *testing.T, dir, stack, composeFile, content string) (string, string) {
+	repo, err := gogit.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("PlainInit failed: %v", err)
+	}
+
+	revision := "master"
+	if err := writeComposeFile(dir, stack, composeFile, content); err != nil {
+		t.Fatalf("writeComposeFile failed: %v", err)
+	}
+
+	hash := commitAll(t, repo, "initial")
+	if err := repo.Storer.SetReference(plumbing.NewHashReference(plumbing.NewBranchReferenceName(revision), hash)); err != nil {
+		t.Fatalf("set reference failed: %v", err)
+	}
+
+	return revision, hash.String()
+}
+
+func addLocalCommit(t *testing.T, repoPath, stack, composeFile, content string) string {
+	repo, err := gogit.PlainOpen(repoPath)
+	if err != nil {
+		t.Fatalf("PlainOpen failed: %v", err)
+	}
+	if err := writeComposeFile(repoPath, stack, composeFile, content); err != nil {
+		t.Fatalf("writeComposeFile failed: %v", err)
+	}
+
+	hash := commitAll(t, repo, "update")
+	return hash.String()
+}
+
+func writeComposeFile(repoPath, stack, composeFile, content string) error {
+	stackDir := filepath.Join(repoPath, stack)
+	if err := os.MkdirAll(stackDir, 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(stackDir, composeFile), []byte(content), 0644)
+}
+
+func commitAll(t *testing.T, repo *gogit.Repository, message string) plumbing.Hash {
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("Worktree failed: %v", err)
+	}
+	if _, err := wt.Add("."); err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+	hash, err := wt.Commit(message, &gogit.CommitOptions{Author: testAuthor()})
+	if err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+	return hash
+}
+
+func testAuthor() *object.Signature {
+	return &object.Signature{
+		Name:  "Test",
+		Email: "test@example.com",
+		When:  time.Now(),
+	}
+}
+
+func waitForRevision(t *testing.T, store *desiredstate.Store, revision string) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for revision %s", revision)
+		default:
+			snap := store.Get()
+			if snap != nil && snap.Revision == revision {
+				return
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
 }

--- a/backend/tests/integration/dind_update_test.go
+++ b/backend/tests/integration/dind_update_test.go
@@ -1,0 +1,108 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/lucasreiners/docker-cd/internal/config"
+	"github.com/lucasreiners/docker-cd/internal/desiredstate"
+	"github.com/lucasreiners/docker-cd/internal/docker"
+	"github.com/lucasreiners/docker-cd/internal/reconcile"
+	"github.com/lucasreiners/docker-cd/internal/scheduler"
+	"github.com/lucasreiners/docker-cd/tests/integration/dind"
+)
+
+func TestDinD_UpdateCycleUsesLocalClone(t *testing.T) {
+	env := dind.StartT(t)
+	runner := &dindRunner{Host: env.DockerHost}
+
+	if err := os.MkdirAll("/repo", 0755); err != nil {
+		t.Skipf("unable to create /repo: %v", err)
+	}
+
+	stackPath := "updateapp"
+	stackDir := filepath.Join("/repo", stackPath)
+	if err := os.MkdirAll(stackDir, 0755); err != nil {
+		t.Fatalf("failed to create stack dir: %v", err)
+	}
+	composeContent := []byte("services:\n  web:\n    image: nginx:alpine\n")
+	composeFile := "docker-compose.yml"
+	composePath := filepath.Join(stackDir, composeFile)
+	if err := os.WriteFile(composePath, composeContent, 0644); err != nil {
+		t.Fatalf("failed to write compose file: %v", err)
+	}
+
+	composeHash := desiredstate.ComposeHash(composeContent)
+	store := desiredstate.NewStore()
+	store.Set(&desiredstate.Snapshot{
+		Revision:       "rev1",
+		CommitMessage:  "update cycle",
+		RefreshStatus:  desiredstate.RefreshStatusCompleted,
+		UpdatesBlocked: false,
+		Stacks: []desiredstate.StackRecord{
+			{
+				Path:        stackPath,
+				ComposeFile: composeFile,
+				ComposeHash: composeHash,
+				Status:      desiredstate.StackSyncMissing,
+				Content:     composeContent,
+			},
+		},
+	})
+
+	client := docker.NewClient(runner, env.DockerHost)
+	composeRunner := reconcile.NewDockerComposeRunner(runner, env.DockerHost)
+	inspector := reconcile.NewDockerContainerInspector(client)
+	policy := reconcile.DefaultPolicy()
+	reconciler := reconcile.NewReconciler(store, policy, composeRunner, inspector, reconcile.NewAckStore(), "")
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	cfg := config.Config{UpdaterEnabled: true, UpdaterCron: "0 3 * * *"}
+	schedulerSvc, err := scheduler.NewSchedulerService(cfg, logger, store, client, reconciler, nil)
+	if err != nil {
+		t.Fatalf("failed to create scheduler: %v", err)
+	}
+	if schedulerSvc == nil {
+		t.Fatal("expected scheduler to be enabled")
+	}
+
+	if err := schedulerSvc.TriggerUpdateCycle(context.Background()); err != nil {
+		t.Fatalf("TriggerUpdateCycle failed: %v", err)
+	}
+
+	waitForUpdateCompletion(t, schedulerSvc, 30*time.Second)
+	waitForContainers(t, runner, 1, 20*time.Second)
+
+	labels, err := inspector.GetStackLabels(context.Background())
+	if err != nil {
+		t.Fatalf("GetStackLabels failed: %v", err)
+	}
+	meta, ok := labels[stackPath]
+	if !ok {
+		t.Fatalf("expected label metadata for stack %q", stackPath)
+	}
+	if meta.SyncStatus != "synced" {
+		t.Fatalf("expected synced status, got %q", meta.SyncStatus)
+	}
+
+	cleanupStack(t, runner, stackPath)
+}
+
+func waitForUpdateCompletion(t *testing.T, schedulerSvc *scheduler.SchedulerService, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if schedulerSvc.GetUpdateStatus() == nil {
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for update cycle completion")
+}

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -25,9 +25,6 @@ services:
       - UPDATER_CRON=${UPDATER_CRON:-0 3 * * *}
     restart: unless-stopped
 
-volumes:
-  repo-data:
-
   frontend:
     build:
       context: ./frontend
@@ -39,3 +36,6 @@ volumes:
     depends_on:
       - docker-cd
     restart: unless-stopped
+
+volumes:
+  repo-data:

--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -7,6 +7,7 @@ services:
       - "8080:8080"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - repo-data:/repo
     environment:
       - PORT=8080
       - PROJECT_NAME=Docker-CD
@@ -23,6 +24,9 @@ services:
       - UPDATER_ENABLED=${UPDATER_ENABLED:-true}
       - UPDATER_CRON=${UPDATER_CRON:-0 3 * * *}
     restart: unless-stopped
+
+volumes:
+  repo-data:
 
   frontend:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       - "8080:8080"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - repo-data:/repo
     environment:
       - PORT=8080
       - PROJECT_NAME=Docker-CD
@@ -21,6 +22,9 @@ services:
       - UPDATER_ENABLED=${UPDATER_ENABLED:-true}
       - UPDATER_CRON=${UPDATER_CRON:-0 3 * * *}
     restart: unless-stopped
+
+volumes:
+  repo-data:
 
   frontend:
     image: ghcr.io/lucasreiners/docker-cd-frontend:v0.1.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,9 +23,6 @@ services:
       - UPDATER_CRON=${UPDATER_CRON:-0 3 * * *}
     restart: unless-stopped
 
-volumes:
-  repo-data:
-
   frontend:
     image: ghcr.io/lucasreiners/docker-cd-frontend:v0.1.0
     ports:
@@ -35,3 +32,6 @@ volumes:
     depends_on:
       - docker-cd
     restart: unless-stopped
+
+volumes:
+  repo-data:

--- a/frontend/src/components/StatusBadge.vue
+++ b/frontend/src/components/StatusBadge.vue
@@ -75,12 +75,15 @@ type TagType = 'success' | 'warning' | 'error' | 'info' | 'default'
 
 const tagType = computed<TagType>(() => {
   switch (props.status) {
+    case 'completed':
     case 'synced':
       return 'success'
+    case 'refreshing':
     case 'syncing':
       return 'warning'
     case 'failed':
       return 'error'
+    case 'queued':
     case 'missing':
       return 'info'
     case 'deleting':
@@ -92,12 +95,15 @@ const tagType = computed<TagType>(() => {
 
 const statusIcon = computed<Component>(() => {
   switch (props.status) {
+    case 'completed':
     case 'synced':
       return CheckCircle
+    case 'refreshing':
     case 'syncing':
       return SyncIcon
     case 'failed':
       return ErrorIcon
+    case 'queued':
     case 'missing':
       return QuestionIcon
     case 'deleting':

--- a/frontend/src/pages/StacksGrid.vue
+++ b/frontend/src/pages/StacksGrid.vue
@@ -57,13 +57,6 @@
           >
             Updates blocked: {{ store.refreshStatus.blockedReason || 'refresh pending' }}
           </n-text>
-          <n-text
-            v-if="store.refreshStatus.localPath"
-            :depth="3"
-            style="font-size: 11px; margin-top: 2px; display: block"
-          >
-            Local clone: {{ store.refreshStatus.localPath }}
-          </n-text>
         </div>
         <n-button
           size="small"

--- a/frontend/src/pages/StacksGrid.vue
+++ b/frontend/src/pages/StacksGrid.vue
@@ -50,6 +50,20 @@
           <n-text :depth="3" style="font-size: 11px; margin-top: 4px">
             Last refreshed: {{ formatTime(store.refreshStatus.refreshedAt) }}
           </n-text>
+          <n-text
+            v-if="store.refreshStatus.updatesBlocked"
+            type="error"
+            style="font-size: 12px; margin-top: 6px; display: block"
+          >
+            Updates blocked: {{ store.refreshStatus.blockedReason || 'refresh pending' }}
+          </n-text>
+          <n-text
+            v-if="store.refreshStatus.localPath"
+            :depth="3"
+            style="font-size: 11px; margin-top: 2px; display: block"
+          >
+            Local clone: {{ store.refreshStatus.localPath }}
+          </n-text>
         </div>
         <n-button
           size="small"

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -36,6 +36,9 @@ export interface RefreshSnapshot {
   refreshedAt: string
   refreshStatus: 'refreshing' | 'queued' | 'completed' | 'failed'
   refreshError?: string
+  updatesBlocked: boolean
+  blockedReason?: string
+  localPath?: string
 }
 
 declare global {

--- a/specs/008-local-git-clone/checklists/requirements.md
+++ b/specs/008-local-git-clone/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Local Repository Clone
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: March 4, 2026
+**Feature**: [specs/008-local-git-clone/spec.md](specs/008-local-git-clone/spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`

--- a/specs/008-local-git-clone/contracts/api.md
+++ b/specs/008-local-git-clone/contracts/api.md
@@ -1,0 +1,49 @@
+# API Contract: Refresh Status and Blocking
+
+**Feature**: 008-local-git-clone
+**Date**: 2026-03-04
+
+## Overview
+
+This feature extends the refresh status reporting to surface refresh failures and whether reconcile/update operations are blocked.
+
+## REST: GET /api/refresh-status
+
+**Response**: `RefreshSnapshot`
+
+### New Fields
+
+- `updatesBlocked` (boolean, required): Indicates reconcile/update tasks are blocked.
+- `blockedReason` (string, optional): Human-readable reason for blocking.
+- `localPath` (string, optional): Fixed local clone path for diagnostics (e.g., `/repo`).
+
+### Example
+
+```json
+{
+  "revision": "abc123",
+  "commitMessage": "deploy v1",
+  "ref": "main",
+  "refType": "branch",
+  "refreshedAt": "2026-03-04T08:00:00Z",
+  "refreshStatus": "failed",
+  "refreshError": "fetch failed: unauthorized",
+  "updatesBlocked": true,
+  "blockedReason": "refresh failed",
+  "localPath": "/repo"
+}
+```
+
+## SSE: refresh status events
+
+**Event name**: `refresh.status`
+
+**Payload**: Same shape as `RefreshSnapshot`.
+
+### Example
+
+```
+event: refresh.status
+id: 74
+data: {"refreshStatus":"failed","refreshError":"fetch failed","updatesBlocked":true,"blockedReason":"refresh failed","localPath":"/repo"}
+```

--- a/specs/008-local-git-clone/contracts/deployment.md
+++ b/specs/008-local-git-clone/contracts/deployment.md
@@ -1,0 +1,44 @@
+# Deployment Contract: Local Clone Volume
+
+**Feature**: 008-local-git-clone
+**Date**: 2026-03-04
+
+## Overview
+
+The service requires a persistent volume mounted at a fixed path inside the container (default `/repo`). Both local and production compose files must provide this volume.
+
+## Docker Compose Requirements
+
+### Volume
+
+- Name: `repo-data` (or equivalent)
+- Scope: persistent
+
+### Mount
+
+- Container path: `/repo`
+- Access: read-write for the service
+
+### Example (local)
+
+```yaml
+services:
+  docker-cd:
+    volumes:
+      - repo-data:/repo
+
+volumes:
+  repo-data:
+```
+
+### Example (production)
+
+```yaml
+services:
+  docker-cd:
+    volumes:
+      - repo-data:/repo
+
+volumes:
+  repo-data:
+```

--- a/specs/008-local-git-clone/data-model.md
+++ b/specs/008-local-git-clone/data-model.md
@@ -1,0 +1,77 @@
+# Data Model: Local Repository Clone
+
+**Date**: 2026-03-04
+**Feature**: 008-local-git-clone
+
+## Entities
+
+### LocalWorkingCopy
+
+Represents the persistent local clone stored at a fixed path.
+
+**Fields**:
+- `path` (string): Fixed filesystem path, e.g., `/repo`.
+- `revision` (string): The currently checked-out revision (commit hash or ref).
+- `ref` (string): Configured branch/ref name.
+- `lastRefreshedAt` (datetime): Timestamp of last successful refresh.
+- `status` (enum): `ready`, `refreshing`, `failed`.
+- `lastError` (string, optional): Error message for the last failed refresh.
+
+**Relationships**:
+- Used by `RefreshSnapshot` for reporting.
+- Read by `ReconcileRun` and `UpdateCycle` to locate stack files.
+
+---
+
+### RefreshSnapshot (extends existing)
+
+Represents the current refresh status and visibility to UI.
+
+**Existing fields**: `revision`, `commitMessage`, `ref`, `refType`, `refreshedAt`, `refreshStatus`, `refreshError`.
+
+**New fields**:
+- `updatesBlocked` (bool): Indicates reconcile/update tasks are blocked.
+- `blockedReason` (string, optional): Reason for blocking (e.g., last refresh failure).
+- `localPath` (string, optional): Fixed local clone path for diagnostics.
+
+---
+
+### RefreshEvent
+
+Represents a refresh trigger and outcome.
+
+**Fields**:
+- `trigger` (enum): `startup`, `manual`, `webhook`, `periodic`.
+- `startedAt` (datetime)
+- `finishedAt` (datetime, optional)
+- `result` (enum): `success`, `failed`, `canceled`.
+- `error` (string, optional)
+
+---
+
+### TaskGate
+
+Gates reconcile/update tasks on refresh completion.
+
+**Fields**:
+- `activeRefreshTrigger` (enum, optional): Current refresh trigger.
+- `refreshComplete` (bool): Whether the current refresh completed successfully.
+- `blocked` (bool): Indicates tasks must not run.
+- `blockedReason` (string, optional)
+
+---
+
+## State Transitions
+
+### Refresh lifecycle
+
+- `idle` -> `refreshing` (triggered by startup/manual/webhook/periodic)
+- `refreshing` -> `completed` (success)
+- `refreshing` -> `failed` (error)
+- `refreshing` -> `canceled` (if higher-priority refresh is triggered)
+
+### Task gating
+
+- `blocked=false` when refresh succeeded for the trigger.
+- `blocked=true` when refresh fails (until next successful refresh).
+- On refresh trigger, reconcile/update tasks are canceled and blocked until refresh completes.

--- a/specs/008-local-git-clone/plan.md
+++ b/specs/008-local-git-clone/plan.md
@@ -1,0 +1,139 @@
+# Implementation Plan: Local Repository Clone
+
+**Branch**: `008-local-git-clone` | **Date**: 2026-03-04 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/008-local-git-clone/spec.md`
+
+## Summary
+
+Introduce a persistent local working copy of the remote Git repository stored in a Docker volume at a fixed path (for example, `/repo`). Refresh the local clone on startup and on manual/webhook refresh, and enforce gating so reconcile/update tasks only run after the refresh for the same trigger succeeds. If a refresh fails, keep the last successful clone, block reconcile/update, and notify the UI via refresh status. Refresh sync uses fetch + force reset with a fallback to delete-and-reclone. The compose files are updated to mount the volume, and integration tests (including docker-in-docker) validate reconcile and update flows.
+
+## Technical Context
+
+**Language/Version**: Go 1.26.0
+**Primary Dependencies**: gin (HTTP), go-git (Git access), Docker CLI via CommandRunner, testcontainers-go (integration)
+**Storage**: Filesystem-backed Git clone in a Docker volume; in-memory desired-state store
+**Testing**: `go test` unit tests; integration tests under `backend/tests/integration` (docker-in-docker)
+**Target Platform**: Linux container runtime (Docker)
+**Project Type**: Long-lived containerized service with web UI
+**Performance Goals**: Refresh completes within 60 seconds for repositories up to 200 MB (SC-001)
+**Constraints**: Remote repo is source of truth; no push from local; reconcile/update must not race refresh; fixed clone path
+**Scale/Scope**: Single repository per instance; tens of stacks per repo
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### Initial Check (Pre-Phase 0)
+
+- **I. GitOps Source of Truth**: ✅ PASS - Local clone is read-only and always reset from the remote; no local pushes.
+- **II. Continuous Reconciliation**: ✅ PASS - Refresh still triggers reconciliation; gating ensures consistency without removing webhook or polling behavior.
+- **III. Container-First Runtime**: ✅ PASS - Uses a Docker volume and fixed in-container path; no host-only assumptions.
+- **IV. Safe Docker Compose Apply**: ✅ PASS - Reconciliation continues to use `docker compose` and is gated by a successful refresh.
+- **V. Automated Testing Baseline**: ✅ PASS - Plan includes new integration tests (docker-in-docker) and unit coverage.
+
+### Post-Design Re-Evaluation (Phase 1 Complete)
+
+- **I. GitOps Source of Truth**: ✅ PASS - Design uses fetch + force reset with re-clone fallback; remote remains authoritative.
+- **II. Continuous Reconciliation**: ✅ PASS - Reconcile still triggers after refresh; cancellation handles race conditions safely.
+- **III. Container-First Runtime**: ✅ PASS - Persistent volume and fixed path `/repo` are encoded in compose updates.
+- **IV. Safe Docker Compose Apply**: ✅ PASS - No change to compose apply semantics, only input source path.
+- **V. Automated Testing Baseline**: ✅ PASS - Integration tests specified for refresh + reconcile + update flows.
+
+**Result**: All constitution principles satisfied.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/008-local-git-clone/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   ├── api.md
+│   └── deployment.md
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+backend/
+├── cmd/docker-cd/
+│   └── main.go                  # Wire local clone refresh on startup
+├── internal/
+│   ├── config/
+│   │   └── config.go             # No new config env vars; document fixed clone path
+│   ├── git/
+│   │   ├── reader.go             # Existing read-only in-memory path
+│   │   ├── validator.go          # Existing repo validation
+│   │   └── local_clone.go         # [NEW] On-disk clone + refresh helper
+│   ├── refresh/
+│   │   ├── refresh.go             # Ensure refresh uses local clone and gates reconcile
+│   │   └── queue.go               # Enforce refresh ordering and cancellation
+│   ├── reconcile/
+│   │   └── reconcile.go           # Gate/cancel reconcile when refresh runs
+│   ├── scheduler/
+│   │   └── scheduler.go           # Gate/cancel update cycles during refresh
+│   ├── http/
+│   │   └── handler.go             # Surface refresh blocked status to UI
+│   └── desiredstate/
+│       └── state.go               # Store refresh metadata and blocking flags
+└── tests/
+    └── integration/
+        ├── dind_reconcile_test.go # Extend for local clone refresh scenarios
+        └── dind_update_test.go    # [NEW] Update flow integration coverage
+
+docker-compose.yml
+
+docker-compose.local.yaml
+```
+
+**Structure Decision**: Single Go service. Add a new helper under `internal/git` for on-disk clone management, wire refresh to use it, and surface status via existing HTTP/SSE pathways. Update root compose files to mount the volume at `/repo`.
+
+## Complexity Tracking
+
+No constitution violations identified. This section is not required.
+
+## Phase 0: Research
+
+**Status**: ✅ Complete
+
+**Output**: [research.md](research.md)
+
+**Key Decisions**:
+1. Fetch + force reset with delete-and-reclone fallback
+2. Full clone (no shallow depth) for long-lived working copies
+3. Fixed clone path backed by a Docker volume
+4. Refresh cancels reconcile/update and gates until success
+5. UI notification via refresh status API/SSE
+
+## Phase 1: Design
+
+**Status**: ✅ Complete
+
+**Outputs**:
+- [data-model.md](data-model.md)
+- [contracts/api.md](contracts/api.md)
+- [contracts/deployment.md](contracts/deployment.md)
+- [quickstart.md](quickstart.md)
+
+**Entities Defined**:
+1. LocalWorkingCopy
+2. RefreshSnapshot (extended)
+3. RefreshEvent
+4. TaskGate
+
+**Contracts Established**:
+- Refresh status API/SSE extended with `updatesBlocked` and `blockedReason`
+- Deployment requirement for `/repo` volume
+
+**Agent Context Updated**: ✅ Completed (`.specify/scripts/bash/update-agent-context.sh copilot`)
+
+## Next Steps
+
+**Phase 2: Task Breakdown** - Run `/speckit.tasks` to generate implementation tasks.
+
+**Plan Status**: ✅ Ready for task generation

--- a/specs/008-local-git-clone/quickstart.md
+++ b/specs/008-local-git-clone/quickstart.md
@@ -1,0 +1,51 @@
+# Quickstart: Local Repository Clone
+
+**Feature**: 008-local-git-clone
+**Date**: 2026-03-04
+
+## Prerequisites
+
+- Docker and Docker Compose installed
+- GitHub access token with read-only permissions
+
+## Configure Environment
+
+```bash
+export GIT_REPO_URL="https://github.com/your-org/your-repo.git"
+export GIT_ACCESS_TOKEN="<token>"
+export GIT_REVISION="main"
+```
+
+## Run (local)
+
+1. Ensure the local compose file mounts the persistent volume at `/repo`.
+2. Start the service:
+
+```bash
+docker compose up --build
+```
+
+## Run (production)
+
+1. Ensure the production compose file mounts the persistent volume at `/repo`.
+2. Deploy the service as usual (compose, swarm, or equivalent).
+
+## Verify
+
+- Check refresh status:
+
+```bash
+curl http://localhost:8080/api/refresh-status
+```
+
+- Confirm `updatesBlocked=false` after a successful refresh.
+- Trigger manual refresh and confirm status updates in the UI.
+- If a refresh fails, verify `updatesBlocked=true` and `blockedReason` are set until the next successful refresh.
+
+## Integration Tests (Docker-in-Docker)
+
+```bash
+cd backend
+
+go test -tags integration ./tests/integration/... -v
+```

--- a/specs/008-local-git-clone/research.md
+++ b/specs/008-local-git-clone/research.md
@@ -1,0 +1,53 @@
+# Phase 0 Research: Local Repository Clone
+
+**Date**: 2026-03-04
+**Feature**: 008-local-git-clone
+
+## Decision 1: Local clone sync strategy
+
+**Decision**: Use `fetch` + force-reset to the configured remote revision; if fetch/reset fails, delete the local clone and re-clone.
+
+**Rationale**: Preserves the remote as the single source of truth while avoiding unnecessary full re-clones. The fallback path guarantees recovery from corruption or inconsistent state.
+
+**Alternatives considered**:
+- Always delete and re-clone on each refresh (too expensive for larger repos).
+- `git pull --rebase` with conflict resolution (violates “remote is source of truth” and adds manual conflict handling).
+
+## Decision 2: Clone depth
+
+**Decision**: Use a full clone (no shallow depth) for the on-disk working copy.
+
+**Rationale**: Long-lived shallow clones can fail during reset if the target commit is outside the shallow history. Full clones reduce edge cases and simplify recovery logic.
+
+**Alternatives considered**:
+- Shallow clone with periodic deepen (complexity and potential failure modes when revision changes).
+
+## Decision 3: Storage location and lifecycle
+
+**Decision**: Store the local working copy at a fixed in-container path (e.g., `/repo`) backed by a Docker volume. If the local clone is invalid, replace it in-place at the same path.
+
+**Rationale**: A fixed path simplifies compose configuration and ensures reconcile/update tasks have a consistent filesystem location.
+
+**Alternatives considered**:
+- Configurable path via environment variable (adds configuration surface without a clear need).
+- Ephemeral temp directories (breaks reconciliation needing a stable path).
+
+## Decision 4: Refresh gating and task cancellation
+
+**Decision**: When a refresh is triggered, cancel any running reconcile/update tasks and perform refresh immediately. Reconcile/update tasks must wait for the refresh triggered by the same event to complete successfully.
+
+**Rationale**: Prevents race conditions between local clone updates and tasks that read from the clone. Ensures all operations use a consistent repository state.
+
+**Alternatives considered**:
+- Let running tasks finish before refresh (risk of stale data).
+- Allow refresh concurrently (introduces race conditions and inconsistent reads).
+
+## Decision 5: User notification on refresh failures
+
+**Decision**: Expose refresh failures and “updates blocked” status through the existing refresh status API/SSE channels.
+
+**Rationale**: Operators need immediate feedback when refresh fails, and UI needs a clear signal to communicate that updates are blocked.
+
+**Alternatives considered**:
+- Logging only (insufficient for UI feedback).
+- Separate alerting endpoint (adds surface area without clear benefit).

--- a/specs/008-local-git-clone/spec.md
+++ b/specs/008-local-git-clone/spec.md
@@ -1,0 +1,148 @@
+# Feature Specification: Local Repository Clone
+
+**Feature Branch**: `008-local-git-clone`  
+**Created**: March 4, 2026  
+**Status**: Draft  
+**Input**: User description: "Based on the previous findings, I want to create a new feature, where the remote git repository is cloned in a local docker volume. The remote repository is always the single source of truth. No pushing from local to remote. When there is a diff or merge conflicts between local and remote, always replace the local repo with the remote contents. The local clone should be refreshed on application start, as well as, when the refresh button is used or a webhook event is received. that local clone should be used for reconciliation as well as container update tasks."
+
+## Clarifications
+
+### Session 2026-03-04
+
+- Q: If refresh fails, what should happen to the local clone and update flows? -> A: Keep the last successful local clone and block reconcile/update until the next successful refresh.
+- Q: Where should the local working copy live inside the container? -> A: Fixed path inside the container (for example, /repo).
+- Q: What should happen if a refresh is triggered while reconcile/update is running? -> A: Cancel the running reconcile/update and refresh immediately.
+- Q: How should refresh sync the local working copy with the remote? -> A: Fetch and force-reset to the remote revision, falling back to delete-and-reclone on failure.
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - Startup Uses Local Clone (Priority: P1)
+
+As an operator, I want the service to keep a local working copy of the remote repository so that reconcile and update tasks always read from a reliable local source.
+
+**Why this priority**: Without a local working copy, reconcile and update tasks can fail due to missing paths or inconsistent working directories.
+
+**Independent Test**: Can be fully tested by starting the service and verifying it creates or refreshes the local working copy and uses it for reconcile/update tasks.
+
+**Acceptance Scenarios**:
+
+1. **Given** the service starts with valid remote repository access, **When** startup refresh completes, **Then** the local working copy matches the configured remote revision and is used for reconciliation and updates.
+2. **Given** the local working copy is missing at startup, **When** the service initializes, **Then** it creates a fresh local working copy from the remote source.
+
+---
+
+### User Story 2 - Manual and Webhook Refresh (Priority: P2)
+
+As an operator, I want the local working copy to refresh when I trigger a refresh or when a webhook is received, so the system stays aligned to the remote repository.
+
+**Why this priority**: Refresh is a primary control surface for operators and should ensure the local working copy is current.
+
+**Independent Test**: Can be fully tested by triggering a refresh and confirming the local working copy updates to the remote state without restarting.
+
+**Acceptance Scenarios**:
+
+1. **Given** a manual refresh is triggered, **When** the refresh completes, **Then** the local working copy matches the remote repository contents for the configured revision.
+2. **Given** a webhook refresh is received, **When** the refresh completes, **Then** reconcile and update tasks use the refreshed local working copy.
+
+---
+
+### User Story 3 - Local Divergence Recovery (Priority: P3)
+
+As an operator, I want the system to replace a diverged or conflicting local working copy with the remote contents so the remote remains the single source of truth.
+
+**Why this priority**: Prevents local drift or corruption from affecting reconcile or update tasks.
+
+**Independent Test**: Can be fully tested by forcing a local divergence and verifying the local working copy is replaced by remote contents.
+
+**Acceptance Scenarios**:
+
+1. **Given** the local working copy differs from the remote contents, **When** a refresh runs, **Then** the local working copy is replaced with the remote contents.
+2. **Given** the local working copy has conflicts or is corrupted, **When** a refresh runs, **Then** the local working copy is discarded and replaced by the remote contents.
+
+---
+
+[Add more user stories as needed, each with an assigned priority]
+
+### Edge Cases
+
+- Remote repository is temporarily unreachable during refresh.
+- Refresh is triggered while another refresh is in progress.
+- Local working copy exists but is missing required stack directories.
+- Webhook is received with an invalid or unauthorized signature.
+
+## Requirements *(mandatory)*
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right functional requirements.
+-->
+
+### Functional Requirements
+
+- **FR-001**: System MUST maintain a local working copy of the configured remote repository in persistent storage attached to the service.
+- **FR-002**: System MUST refresh the local working copy on application start.
+- **FR-003**: System MUST refresh the local working copy when a manual refresh is triggered.
+- **FR-004**: System MUST refresh the local working copy when a valid webhook refresh event is received.
+- **FR-005**: System MUST treat the remote repository as the single source of truth and MUST NOT push changes from the local working copy back to the remote.
+- **FR-006**: When the local working copy differs from the remote contents, the system MUST replace the local working copy with the remote contents.
+- **FR-007**: When the local working copy is corrupted or conflicts are detected, the system MUST replace the local working copy with the remote contents.
+- **FR-008**: Reconciliation MUST read stack files from the local working copy.
+- **FR-009**: Container update tasks MUST read stack files from the local working copy.
+- **FR-010**: System MUST surface a clear refresh failure status and error message to the user interface when the remote repository cannot be reached.
+- **FR-011**: System MUST prevent concurrent refresh operations from corrupting the local working copy.
+- **FR-012**: The feature MUST be validated with integration tests, including docker-in-docker coverage for reconcile and update flows.
+- **FR-013**: The local and production docker-compose files MUST be updated to include the new persistent volume definition for the local working copy.
+- **FR-014**: Reconciliation and update tasks MUST NOT start until the local working copy refresh completes successfully for the same trigger (startup, manual refresh, or webhook), preventing race conditions.
+- **FR-015**: If a refresh fails, the system MUST keep the last successful local working copy, block reconcile and update tasks, and notify the user interface that updates are blocked.
+- **FR-016**: The local working copy MUST be stored at a fixed path inside the container (for example, /repo) and mounted via the persistent volume.
+- **FR-017**: If a refresh is triggered while reconcile or update tasks are running, the system MUST cancel those tasks and perform the refresh immediately.
+- **FR-018**: Refresh MUST sync the local working copy by fetching and force-resetting to the remote revision; if that fails, the system MUST delete the local working copy and re-clone from the remote.
+
+### Scope
+
+- The local working copy is intended only for read and refresh operations.
+- The feature applies to the configured repository and revision only.
+- There is no requirement to support multiple repositories in a single instance.
+
+### Assumptions
+
+- Persistent storage is provided to the service so the local working copy survives restarts.
+- The remote repository is reachable using existing access credentials.
+- The refresh triggers (startup, manual, webhook) already exist as control surfaces.
+
+### Dependencies
+
+- Remote repository access credentials and revision configuration are valid.
+
+### Key Entities *(include if feature involves data)*
+
+- **Local Working Copy**: The persistent local repository state used by reconcile and update tasks; attributes include repository source, revision, last refreshed time, and health status.
+- **Refresh Event**: A trigger for refreshing the local working copy; attributes include trigger type (startup, manual, webhook), timestamp, and outcome.
+- **Remote Repository**: The authoritative source; attributes include repository URL and configured revision.
+
+## Success Criteria *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Define measurable success criteria.
+  These must be technology-agnostic and measurable.
+-->
+
+### Measurable Outcomes
+
+- **SC-001**: 99% of refresh operations complete successfully within 60 seconds for repositories up to 200 MB.
+- **SC-002**: After each refresh, the local working copy matches the configured remote revision with 100% accuracy.
+- **SC-003**: Reconcile and update tasks read from the local working copy in 100% of runs.
+- **SC-004**: Refresh failure events are reported within 5 seconds of detection.

--- a/specs/008-local-git-clone/tasks.md
+++ b/specs/008-local-git-clone/tasks.md
@@ -1,0 +1,152 @@
+---
+
+description: "Task list for 008-local-git-clone"
+
+---
+
+# Tasks: Local Repository Clone
+
+**Input**: Design documents from `/specs/008-local-git-clone/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+**Tests**: Required (integration tests requested, including docker-in-docker)
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Deployment scaffolding for persistent local clone
+
+- [x] T001 Update docker-compose.yml to add repo volume mount at /repo in docker-compose.yml
+- [x] T002 Update docker-compose.local.yaml to add repo volume mount at /repo in docker-compose.local.yaml
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core state and API surface shared across all user stories
+
+- [x] T003 Extend refresh status model with updatesBlocked, blockedReason, localPath in backend/internal/desiredstate/state.go
+- [x] T004 Update refresh status API response to include new fields in backend/internal/http/handler.go
+- [x] T005 Update refresh status SSE payload to include new fields in backend/internal/desiredstate/broadcaster.go
+
+**Checkpoint**: Refresh status can represent blocked state and local clone path
+
+---
+
+## Phase 3: User Story 1 - Startup Uses Local Clone (Priority: P1) 🎯 MVP
+
+**Goal**: Create and use a persistent local clone on startup, and gate reconcile/update tasks on refresh completion.
+
+**Independent Test**: Start the service with valid repo access and verify the local clone is created at /repo and reconcile/update only run after a successful startup refresh.
+
+### Tests for User Story 1 (Required)
+
+- [x] T006 [P] [US1] Unit tests for LocalClone open/clone and fetch/reset in backend/internal/git/local_clone_test.go
+- [x] T007 [P] [US1] Integration test for startup refresh + reconcile gating in backend/tests/integration/dind_reconcile_test.go
+
+### Implementation for User Story 1
+
+- [x] T008 [US1] Implement LocalClone helper for on-disk clone management in backend/internal/git/local_clone.go
+- [x] T009 [US1] Wire startup refresh to use LocalClone in backend/internal/refresh/refresh.go
+- [x] T010 [US1] Gate reconcile on successful refresh completion in backend/internal/reconcile/reconcile.go
+- [x] T011 [US1] Gate update cycles on successful refresh completion in backend/internal/scheduler/scheduler.go
+- [x] T012 [US1] Use local clone path for stack file reads in backend/internal/refresh/refresh.go
+
+**Checkpoint**: Startup refresh produces a local clone at /repo and reconcile/update are gated on refresh success
+
+---
+
+## Phase 4: User Story 2 - Manual and Webhook Refresh (Priority: P2)
+
+**Goal**: Refresh the local clone on manual and webhook triggers, and notify UI when refresh fails or updates are blocked.
+
+**Independent Test**: Trigger manual refresh and webhook refresh and confirm refresh status updates and tasks are blocked on failure.
+
+### Tests for User Story 2 (Required)
+
+- [x] T013 [P] [US2] Integration test for manual refresh updating local clone in backend/tests/integration/dind_reconcile_test.go
+- [x] T014 [P] [US2] Integration test for refresh status blocked notification in backend/tests/integration/dind_reconcile_test.go
+
+### Implementation for User Story 2
+
+- [x] T015 [US2] Update refresh trigger handling to cancel running reconcile/update tasks in backend/internal/refresh/refresh.go
+- [x] T016 [US2] Emit updatesBlocked and blockedReason on refresh failure in backend/internal/desiredstate/state.go
+- [x] T017 [US2] Broadcast refresh.status SSE updates on refresh transitions in backend/internal/desiredstate/broadcaster.go
+- [x] T018 [US2] Ensure webhook refresh uses LocalClone and respects gating in backend/internal/http/handler.go
+
+**Checkpoint**: Manual/webhook refreshes update the local clone and UI receives blocked status on failure
+
+---
+
+## Phase 5: User Story 3 - Local Divergence Recovery (Priority: P3)
+
+**Goal**: Replace diverged or corrupted local clones with remote contents using fetch/reset with re-clone fallback.
+
+**Independent Test**: Corrupt the local clone and verify refresh replaces it with a clean clone from remote.
+
+### Tests for User Story 3 (Required)
+
+- [x] T019 [P] [US3] Unit test for re-clone fallback when LocalClone refresh fails in backend/internal/git/local_clone_test.go
+- [x] T020 [P] [US3] Integration test for divergence recovery via refresh in backend/tests/integration/dind_reconcile_test.go
+
+### Implementation for User Story 3
+
+- [x] T021 [US3] Implement fetch + force reset with re-clone fallback in backend/internal/git/local_clone.go
+- [x] T022 [US3] Record refresh failure details for blocked UI status in backend/internal/refresh/refresh.go
+
+**Checkpoint**: Local divergence recovery works and blocked status is accurate
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation and comprehensive integration coverage
+
+- [x] T023 [P] Expand docker-in-docker update cycle coverage in backend/tests/integration/dind_update_test.go
+- [x] T024 [P] Update README.md with /repo volume requirement and blocked refresh behavior in README.md
+- [x] T025 [P] Validate quickstart instructions with new volume requirement in specs/008-local-git-clone/quickstart.md
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies
+- **Foundational (Phase 2)**: Depends on Setup completion
+- **User Stories (Phase 3-5)**: Depend on Foundational completion
+- **Polish (Phase 6)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: No dependencies after Foundational
+- **User Story 2 (P2)**: Depends on US1 LocalClone usage
+- **User Story 3 (P3)**: Depends on US1 LocalClone usage
+
+### Parallel Opportunities
+
+- Tests within each story marked [P] can be done in parallel
+- Integration tests in US2/US3 can be written in parallel once LocalClone scaffolding exists
+- Documentation updates in Phase 6 can be done in parallel
+
+---
+
+## Parallel Example: User Story 1
+
+- T006 [US1] Unit tests for LocalClone open/clone and fetch/reset in backend/internal/git/local_clone_test.go
+- T007 [US1] Integration test for startup refresh + reconcile gating in backend/tests/integration/dind_reconcile_test.go
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Setup (Phase 1)
+2. Complete Foundational (Phase 2)
+3. Complete User Story 1 (Phase 3)
+4. Validate with unit + integration tests for US1
+
+### Incremental Delivery
+
+1. Add User Story 2 with refresh trigger coverage
+2. Add User Story 3 divergence recovery
+3. Finish polish tasks and documentation


### PR DESCRIPTION
## Summary
- add persistent local repo clone with refresh gating and cancellation
- expose refresh blocked status via API/SSE and update compose mounts
- surface refresh blocked status and local clone path in the UI
- extend integration coverage for refresh/reconcile/update flows