### PR TITLE
feat: replace Docker CLI shelling with Go SDK for image operations

### DIFF
--- a/.lead/_adhoc/docker-sdk-refactor.md
+++ b/.lead/_adhoc/docker-sdk-refactor.md
@@ -1,0 +1,230 @@
+# Refactor Docker CLI Shelling to Docker Go SDK
+
+## TL;DR
+> **Summary**: Replace `os/exec` CLI shelling for image and container operations with the Docker Go SDK (`github.com/docker/docker/client`), replace `docker compose config --images` with direct YAML parsing, and wire streaming image pull progress through SSE to the frontend — eliminating all `CommandRunner` usage from `docker.Client`.
+> **Estimated Effort**: Large
+
+## Context
+### Original Request
+Replace Docker CLI shelling (`docker ps`, `docker inspect`, `docker image prune`, `docker compose pull`, `docker compose config --images`) with the Docker Go SDK and YAML parsing for image operations, container listing, and container inspection. Keep `docker compose` CLI only for `up`/`down`/`ps` (compose orchestration). Wire streaming pull progress to the existing SSE broadcaster so the frontend shows per-image download status.
+
+### Key Findings
+- **`docker.Client`** (client.go) wraps a `CommandRunner` and socket string. Methods: `ContainerCount`, `ListContainersWithLabel`, `PullImages`, `PruneImages`, `GetImageDigest`, `GetComposeImages`.
+- **`CommandRunner`** interface (runner.go) is a simple `Run(ctx, name, args...) ([]byte, error)`. Used by both `docker.Client` and `reconcile.DockerComposeRunner`.
+- **`ImageOperations`** interface (images.go) defines `PullImages`, `PruneImages`, `GetImageDigest`, `GetComposeImages` — but nothing consumes it via the interface; `scheduler.go` uses `*docker.Client` directly.
+- **`DockerContainerInspector`** (metadata.go) wraps `*docker.Client` for `GetStackLabels` → calls `ListContainersWithLabel`.
+- **`DockerComposeRunner`** (compose.go) uses `CommandRunner` for `ComposeUp`, `ComposeDown`, `ComposePs`. These **stay as CLI**.
+- **`PullImages`** currently calls `docker compose pull` — the SDK replacement should pull each image individually via `client.ImagePull()`, enabling streaming JSON progress.
+- **`GetComposeImages`** calls `docker compose config --images`. This can be replaced by YAML parsing since `stack.Content` (raw compose bytes) is already available on `StackRecord`. The codebase has `extractServiceNames()` in `reconcile/compose.go` as a pattern for lightweight YAML line parsing.
+- **`updateStack`** in scheduler.go already has access to `stack` (`desiredstate.StackRecord`) which carries `.Content` — but currently ignores it and reads from the filesystem path. The image list can be extracted from `.Content` directly.
+- **`go.mod`** already has `github.com/docker/docker v28.5.2` as an indirect dep (from testcontainers). Promoting to direct is trivial.
+- **34 unit tests** use `stubRunner`/`multiStubRunner` to mock CLI output. SDK-based methods need a new mockable interface.
+- **SSE**: `Broadcaster.PublishUpdateProgress` already sends `update.progress` events with `type` field (`started`, `stack_progress`, `stack_success`, `stack_error`, `completed`, `pruning`). Frontend `stacks.ts` stores `updateProgress` and checks `progress.type` for `started`/`completed`. A new `image_pull_progress` type will pass through transparently — frontend just needs to handle the new type.
+- The SDK's `client.NewClientWithOpts()` accepts `client.WithHost()` for socket configuration — maps directly to the current `Socket` field.
+
+## Objectives
+### Core Objective
+Replace all CLI-shelled Docker operations in `docker.Client` with SDK calls and YAML parsing, enable streaming pull progress piped to SSE, and fully remove `CommandRunner` from the image/container path.
+
+### Deliverables
+- A `DockerAPI` interface abstracting SDK operations (mockable for tests)
+- SDK-based `ContainerCount`, `ListContainersWithLabel`, `PullImages`, `PruneImages`, `GetImageDigest`
+- `ExtractComposeImages()` function replacing `GetComposeImages` CLI call
+- Streaming progress on `PullImages` piped through scheduler to SSE broadcaster
+- Frontend handling of `image_pull_progress` events
+- Updated tests using mock `DockerAPI` instead of `stubRunner` for SDK-migrated methods
+- `CommandRunner` fully removed from `docker.Client` (retained only for `DockerComposeRunner`)
+
+### Definition of Done
+- `cd backend && go test ./...` passes
+- `PullImages` accepts a progress callback and streams per-image progress (verified by test with mock reader)
+- `GetComposeImages` is removed from `docker.Client`; image extraction uses YAML parsing
+- No remaining `CommandRunner` usage in `docker.Client`
+- `DockerComposeRunner` still uses `CommandRunner` for `ComposeUp`/`ComposeDown`/`ComposePs`
+- SSE emits `image_pull_progress` events during image pulls
+- Frontend displays per-image pull progress
+
+### Guardrails (Must NOT)
+- Change the `ComposeRunner` interface contract
+- Break existing test assertions (observable outcomes unchanged)
+- Change status flow: missing→syncing→synced/failed
+- Change reconciliation or drift detection logic
+- Break existing SSE event types (`started`, `stack_progress`, `stack_success`, `stack_error`, `completed`, `pruning`) — new type is additive
+- Attempt to parse `build:` directives as pullable images — services with `build:` and no `image:` must be skipped
+
+## Progress
+
+- [x] 1. Define DockerAPI Interface and SDK Client
+- [x] 2. Migrate ContainerCount to SDK
+- [x] 3. Migrate ListContainersWithLabel to SDK
+- [x] 4. Migrate GetImageDigest to SDK
+- [x] 5. Migrate PruneImages to SDK
+- [x] 6. Extract Compose Images via YAML Parsing
+- [x] 7. Migrate PullImages to SDK with Progress Callback
+- [x] 8. Wire Pull Progress to SSE Broadcaster
+- [x] 9. Update Scheduler and Inspector to Use New Client
+- [x] 10. Remove CommandRunner from docker.Client
+- [x] All tests pass
+- [x] No regressions
+
+## TODOs
+
+### 1. Define DockerAPI Interface and SDK Client
+**What**: Create a `DockerAPI` interface in `internal/docker/` that wraps the subset of `github.com/docker/docker/client` methods we need. Create an SDK-backed implementation and a constructor that accepts the socket string. Promote `docker/docker` to a direct dependency in `go.mod`.
+
+The interface should wrap exactly these SDK methods:
+```go
+type DockerAPI interface {
+    ContainerList(ctx context.Context, options container.ListOptions) ([]types.Container, error)
+    ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error)
+    ImageInspectWithRaw(ctx context.Context, imageID string) (types.ImageInspect, []byte, error)
+    ImagePull(ctx context.Context, refStr string, options image.PullOptions) (io.ReadCloser, error)
+    ImagesPrune(ctx context.Context, pruneFilters filters.Args) (image.PruneReport, error)
+}
+```
+
+Create `NewSDKClient(socket string) (DockerAPI, error)` that calls `client.NewClientWithOpts(client.WithHost(...), client.WithAPIVersionNegotiation())`. Handle the socket→host URL conversion (reuse `HostArgs` logic: bare path → `unix:///path`, already-prefixed → pass through, empty → use `client.FromEnv`).
+
+**Files**: `internal/docker/sdk.go` (new), `go.mod`, `go.sum`
+**Acceptance**: `go build ./...` succeeds; new file compiles; `DockerAPI` interface exists and is satisfied by `*client.Client`
+
+### 2. Migrate ContainerCount to SDK
+**What**: Rewrite `Client.ContainerCount` to use `DockerAPI.ContainerList` with `filters.NewArgs()` and count the results instead of parsing `docker ps -q` output. Add `DockerAPI` field to `Client` struct alongside existing `Runner`. Update `NewClient` to accept `DockerAPI` (or add a setter/alternate constructor).
+
+Update tests: replace `stubRunner` with a mock `DockerAPI` that returns `[]types.Container` slices.
+
+**Files**: `internal/docker/client.go`, `internal/docker/client_test.go`
+**Acceptance**: `go test ./internal/docker/...` passes; `ContainerCount` no longer calls `Runner.Run`
+
+### 3. Migrate ListContainersWithLabel to SDK
+**What**: Rewrite `Client.ListContainersWithLabel` to use `DockerAPI.ContainerList` with label filter (`filters.NewArgs(filters.Arg("label", labelKey))`). The SDK returns `types.Container` with `.ID`, `.Names`, `.Labels` — no need for the two-step ps+inspect approach.
+
+Update tests to use mock `DockerAPI`.
+
+**Files**: `internal/docker/client.go`, `internal/docker/client_test.go`
+**Acceptance**: `go test ./internal/docker/...` passes; same `[]ContainerLabels` output shape
+
+### 4. Migrate GetImageDigest to SDK
+**What**: Rewrite `Client.GetImageDigest` to use `DockerAPI.ImageInspectWithRaw`. Return `inspect.ID` (which is the `sha256:...` digest).
+
+Update tests.
+
+**Files**: `internal/docker/images.go`, `internal/docker/client_test.go`
+**Acceptance**: `go test ./internal/docker/...` passes; returns same digest format
+
+### 5. Migrate PruneImages to SDK
+**What**: Rewrite `Client.PruneImages` to use `DockerAPI.ImagesPrune` with `filters.NewArgs(filters.Arg("dangling", "false"))` (equivalent to `-a`). The SDK returns `image.PruneReport` with `.ImagesDeleted` (count) and `.SpaceReclaimed` (uint64 bytes). Convert bytes to human-readable string to match current return signature.
+
+Update tests.
+
+**Files**: `internal/docker/images.go`, `internal/docker/client_test.go`
+**Acceptance**: `go test ./internal/docker/...` passes; same `(int, string, error)` signature
+
+### 6. Extract Compose Images via YAML Parsing
+**What**: Create an `ExtractComposeImages(content []byte) []string` function that parses raw compose YAML to extract the `image:` value for each service. Follow the same lightweight line-parsing approach as `extractServiceNames()` in `reconcile/compose.go`.
+
+The parser should:
+1. Find each service block under `services:`
+2. Within each service block, look for an `image:` key
+3. Skip services that have `build:` but no `image:` (these are built locally, not pulled)
+4. Return deduplicated image names (multiple services can reference the same image)
+5. Handle quoted and unquoted values, trailing whitespace, comments
+
+Place this in `internal/reconcile/compose.go` next to `extractServiceNames()` since it follows the same pattern and operates on the same compose content.
+
+Remove `GetComposeImages` from `docker.Client` and the `ImageOperations` interface. Update `updateStack` in scheduler.go to call `ExtractComposeImages(stack.Content)` instead of `s.dockerClient.GetComposeImages(ctx, ...)` — this eliminates the need for filesystem access and `CommandRunner` in the image discovery path.
+
+**Files**: `internal/reconcile/compose.go`, `internal/reconcile/extract_test.go`, `internal/docker/images.go` (remove `GetComposeImages`), `internal/scheduler/scheduler.go` (update `updateStack`)
+**Acceptance**: `go test ./internal/reconcile/...` passes with new tests covering: single image, multiple services, `build:`-only services skipped, `build:` + `image:` included, deduplication, empty content, quoted values. `go test ./internal/scheduler/...` passes. `GetComposeImages` no longer exists on `Client`.
+
+### 7. Migrate PullImages to SDK with Progress Callback
+**What**: Rewrite `Client.PullImages` to pull individual images via the SDK. Change the signature to accept an image list and a progress callback:
+
+```go
+type PullProgress struct {
+    Image    string `json:"image"`
+    Status   string `json:"status"`
+    Progress string `json:"progress"`   // e.g. "[===>     ] 12MB/45MB"
+    Current  int    `json:"current"`    // image index (1-based)
+    Total    int    `json:"total"`      // total images
+}
+
+type PullProgressFn func(PullProgress)
+
+func (c *Client) PullImages(ctx context.Context, images []string, onProgress PullProgressFn) error
+```
+
+For each image:
+1. Call `DockerAPI.ImagePull` which returns `io.ReadCloser`
+2. Decode the JSON stream line-by-line (`{"status":"Pulling...","progress":"[===>  ]","id":"layer-id"}`)
+3. Invoke `onProgress` with coalesced status (throttle to ~1 call per 500ms per image to avoid flooding SSE)
+4. Read to EOF to ensure pull completes
+5. On error, wrap with image name context
+
+If `onProgress` is nil, progress is silently consumed (drain to EOF).
+
+Remove the old `PullImages(ctx, projectName, composeFile, workDir)` signature. Update `ImageOperations` interface accordingly. Update `updateStack` in scheduler.go to pass the image list (from Task 6) and a progress callback (wired in Task 8).
+
+**Files**: `internal/docker/images.go`, `internal/docker/client_test.go`, `internal/scheduler/scheduler.go`
+**Acceptance**: `go test ./internal/docker/...` passes; mock `DockerAPI.ImagePull` returns `bytes.Reader` with sample JSON lines; progress callback receives expected events; pull reads stream to completion
+
+### 8. Wire Pull Progress to SSE Broadcaster
+**What**: In `scheduler.go`'s `updateStack`, construct a `PullProgressFn` that calls `s.broadcaster.PublishUpdateProgress` with a new event sub-type `image_pull_progress`. The payload structure:
+
+```json
+{
+  "type": "image_pull_progress",
+  "cycle_id": "...",
+  "stack": "app1",
+  "image": "nginx:latest",
+  "status": "Downloading",
+  "progress": "[===>     ] 12MB/45MB",
+  "current": 1,
+  "total": 3,
+  "timestamp": "..."
+}
+```
+
+This uses the existing `EventUpdateProgress` event type and `PublishUpdateProgress` method — no changes to the broadcaster needed. The frontend needs to handle the new `image_pull_progress` type in `stacks.ts`.
+
+On the frontend side, update `stacks.ts` to store `image_pull_progress` events (they pass through `onUpdateProgress` already). Add display logic in the update progress UI component to show the current image being pulled and its download progress.
+
+**Files**: `internal/scheduler/scheduler.go`, `frontend/src/store/stacks.ts`
+**Acceptance**: `go test ./internal/scheduler/...` passes; when `PullImages` runs, SSE emits `image_pull_progress` events; frontend store handles the new event type without errors
+
+### 9. Update Scheduler and Inspector to Use New Client
+**What**: Update `scheduler.go` to work with the refactored `docker.Client` (which now uses `DockerAPI` internally). Key changes:
+- `updateStack` now calls `reconcile.ExtractComposeImages(stack.Content)` instead of `s.dockerClient.GetComposeImages`
+- `updateStack` passes image list + progress callback to `s.dockerClient.PullImages(ctx, images, onProgress)`
+- Verify `DockerContainerInspector` works with the updated `Client` (should be transparent since `ListContainersWithLabel` keeps the same signature)
+
+Wire up SDK client creation in `main.go` or wherever `docker.NewClient` is called: create the `DockerAPI` via `NewSDKClient(socket)` and pass it to `NewClient`.
+
+Verify `scheduler_test.go` and `updater_test.go` still pass — these mock at the `ImageOperations`/`ComposeRunner`/`ContainerInspector` interface level. The `ImageOperations` interface needs updating to match the new `PullImages` signature, and test mocks need to follow.
+
+**Files**: `internal/reconcile/metadata.go`, `internal/scheduler/scheduler.go`, `internal/scheduler/scheduler_test.go`, `internal/scheduler/updater_test.go`, `cmd/server/main.go` (or equivalent entrypoint)
+**Acceptance**: `go test ./...` passes; application starts and connects to Docker
+
+### 10. Remove CommandRunner from docker.Client
+**What**: Remove the `Runner CommandRunner` field and `Socket string` field from `docker.Client` since all its methods now use `DockerAPI`. Remove `GetComposeImages` (already done in Task 6) and the `HostArgs` function from `client.go` — move `HostArgs` to `reconcile/compose.go` where `DockerComposeRunner` still needs it, or keep it in `runner.go`.
+
+`CommandRunner` stays in `runner.go` for `DockerComposeRunner`'s use only. Update `NewClient` to accept only `DockerAPI`. Update all callers.
+
+Audit completeness:
+- `grep -r 'c\.Runner' internal/docker/` returns nothing
+- `grep -r 'CommandRunner' internal/docker/client.go` returns nothing
+- `HostArgs` only referenced from `reconcile/compose.go`
+
+**Files**: `internal/docker/client.go`, `internal/docker/runner.go` (keep file), `internal/reconcile/compose.go` (import `HostArgs` or inline), all callers of `NewClient`
+**Acceptance**: `go test ./...` passes; `Client` struct has no `Runner` field; `CommandRunner` not imported in `client.go`
+
+### Verification
+- All tests pass: `cd backend && go test ./...`
+- No regressions: all 34 existing unit tests pass with equivalent assertions (some rewritten for mock `DockerAPI`)
+- `PullImages` streams progress via callback (test with mock `io.ReadCloser`)
+- `docker.Client` has zero `CommandRunner` usage
+- `GetComposeImages` CLI call eliminated; YAML parsing used instead
+- `DockerComposeRunner` still uses `CommandRunner` for compose CLI ops
+- SSE emits `image_pull_progress` events during pulls
+- Frontend handles new event type
+- Application builds: `cd backend && go build ./...`

--- a/.lead/_adhoc/pre-refactor-unit-tests.md
+++ b/.lead/_adhoc/pre-refactor-unit-tests.md
@@ -1,0 +1,143 @@
+# Pre-SDK-Refactor Unit Tests
+
+## TL;DR
+> **Summary**: Add unit tests to lock down observable CLI behaviors (args built, status transitions, JSON parsing, error handling) before replacing Docker CLI shelling with the Go SDK.
+> **Estimated Effort**: Medium
+
+## Context
+### Original Request
+Before refactoring from Docker CLI (`CommandRunner`) to the Docker Go SDK, we need unit tests that capture *what* each function does — the args it passes, the status transitions it triggers, and the errors it returns — so the SDK replacement can be verified against identical observable behavior.
+
+### Key Findings
+- `DockerComposeRunner` methods (`ComposeUp`, `ComposeDown`, `ComposePs`) build CLI args via `docker.HostArgs()` and call `runner.Run()`. Tests need an `argCapturingRunner` (pattern exists in `docker/client_test.go`).
+- `reconcile_test.go` already has a `stubComposeRunner` that records calls at the `ComposeRunner` interface level — good for reconciler tests but doesn't capture raw CLI args. A new `compose_test.go` in the `reconcile` package (internal, not `_test`) needs an arg-capturing `CommandRunner` stub.
+- `generateLabelOverride` and `generateLabelArgs` are unexported but `export_test_helpers.go` already exposes `TestGenerateLabelOverride`. `generateLabelArgs` needs a similar export or tests in the `reconcile` package (not `_test`).
+- `CancelActive()` and `CancelActiveUpdate()` use mutex-guarded `context.CancelFunc` — testable by starting a reconcile/update in a goroutine and verifying context cancellation.
+- `UpdateContainerCounts()` calls `ComposePs` then writes counts to the store — fully testable with the existing `stubComposeRunner` pattern extended to return container data.
+- `AllLabelKeys()` is a pure function — trivial to test.
+- Test style: manual `if` checks with `t.Errorf`/`t.Fatalf`, no testify. Table-driven where useful.
+
+## Objectives
+### Core Objective
+Create a regression-safe test suite that captures the observable contract of every function that will be touched during the SDK migration.
+
+### Deliverables
+- `internal/reconcile/compose_test.go` — ComposeUp/Down/Ps arg + behavior tests
+- `internal/reconcile/labels_test.go` — label generation tests
+- `internal/reconcile/state_manager_test.go` — UpdateContainerCounts tests
+- Extended `internal/reconcile/reconcile_test.go` — CancelActive test
+- Extended `internal/scheduler/scheduler_test.go` — CancelActiveUpdate test
+
+### Definition of Done
+- `cd backend && go test ./internal/reconcile/... ./internal/scheduler/... -count=1` passes
+- Every function listed in scope has ≥1 test covering its happy path and ≥1 covering its error path
+
+### Guardrails (Must NOT)
+- Must NOT use testify or any external test dependency
+- Must NOT require Docker-in-Docker or build tags
+- Must NOT test implementation details that will change (e.g. exact temp dir paths)
+- Must NOT duplicate existing test coverage in `reconcile_test.go`
+
+## Progress
+
+- [x] 1. ComposeUp arg-capture tests
+- [x] 2. ComposeDown arg-capture tests
+- [x] 3. ComposePs JSON parsing tests
+- [x] 4. generateLabelArgs + generateLabelOverride tests
+- [x] 5. CancelActive context cancellation test
+- [x] 6. CancelActiveUpdate cancellation test
+- [x] 7. UpdateContainerCounts store update test
+- [x] 8. AllLabelKeys completeness test
+- [x] All tests pass
+- [x] No regressions
+
+## TODOs
+
+### 1. ComposeUp arg-capture tests
+**What**: Create an `argCapturingRunner` (implements `docker.CommandRunner`) in a new `compose_test.go`. Write tests verifying:
+- Base args include `-H unix:///socket` when socket is set
+- Args contain `compose -p <project> -f <file> up -d`
+- `--project-directory` is included when `workDir` is non-empty
+- Override file `-f <override>` is included when `overrideFile` is non-empty
+- Override file is absent when `overrideFile` is empty
+- Error from runner propagates wrapped in `"docker compose up failed: ..."`
+**Files**: `backend/internal/reconcile/compose_test.go` (new, package `reconcile` — internal access)
+**Acceptance**: `go test ./internal/reconcile/ -run TestComposeUp -v` passes with ≥4 subtests
+
+### 2. ComposeDown arg-capture tests
+**What**: In the same `compose_test.go`, test `ComposeDown`:
+- Args contain `compose -p <project> down --remove-orphans`
+- `--project-directory` present when `workDir` set
+- `-f <file>` present when `composeFile` non-empty, absent when empty
+- Error wrapping matches `"docker compose down failed: ..."`
+**Files**: `backend/internal/reconcile/compose_test.go`
+**Acceptance**: `go test ./internal/reconcile/ -run TestComposeDown -v` passes with ≥3 subtests
+
+### 3. ComposePs JSON parsing tests
+**What**: Test `ComposePs` with stubbed runner output:
+- Single container JSON line → returns 1 `ContainerInfo` with correct fields (ID truncated to 12 chars, Name, Service, State, Health, Image, Ports)
+- Multiple JSON lines → returns multiple containers
+- Empty output → returns nil, nil
+- Health defaults to `"none"` when omitted from JSON
+- Published ports format: `published:target/proto` vs `target/proto` when unpublished
+- Invalid JSON lines are skipped silently
+- Runner error propagates
+**Files**: `backend/internal/reconcile/compose_test.go`
+**Acceptance**: `go test ./internal/reconcile/ -run TestComposePs -v` passes with ≥5 subtests
+
+### 4. generateLabelArgs + generateLabelOverride tests
+**What**: Test both label-generation functions:
+- `generateLabelArgs` returns map with all 7 expected keys (`LabelStackPath`, `LabelDesiredRevision`, `LabelDesiredCommitMessage`, `LabelDesiredComposeHash`, `LabelSyncedAt`, `LabelSyncAt`, `LabelSyncStatus`)
+- `LabelSyncStatus` value is `"synced"`
+- Values match inputs (stackPath, revision, commitMessage, composeHash)
+- `generateLabelOverride` produces valid YAML-ish structure with `services:` header and all labels per service
+- Empty `serviceNames` returns `""`
+- `escapeYAMLValue` handles quotes and newlines (test via `generateLabelOverride` with commit messages containing those)
+- Use `TestGenerateLabelOverride` export for `_test` package tests, or write internal package tests
+
+Note: `generateLabelArgs` is unexported. Either add an `export_test_helpers.go` entry or write these tests in package `reconcile` (not `reconcile_test`).
+**Files**: `backend/internal/reconcile/labels_test.go` (new) + possibly `backend/internal/reconcile/export_test_helpers.go` (add `TestGenerateLabelArgs` export)
+**Acceptance**: `go test ./internal/reconcile/ -run TestGenerateLabel -v` passes with ≥4 subtests
+
+### 5. CancelActive context cancellation test
+**What**: Test `Reconciler.CancelActive()`:
+- Start a `Reconcile()` in a goroutine with a `stubComposeRunner` that blocks on `ComposeUp` (using a channel)
+- Call `CancelActive()` from the main goroutine
+- Verify the blocked `ComposeUp` receives context cancellation
+- Verify `CancelActive()` is safe to call when no reconciliation is active (no panic)
+**Files**: `backend/internal/reconcile/reconcile_test.go` (append)
+**Acceptance**: `go test ./internal/reconcile/ -run TestCancelActive -v -timeout=5s` passes
+
+### 6. CancelActiveUpdate cancellation test
+**What**: Test `SchedulerService.CancelActiveUpdate()`:
+- Create scheduler with a `mockRunner` that has `pullDelay` set
+- Trigger an update cycle
+- Call `CancelActiveUpdate()`
+- Verify the cycle terminates early (fewer stacks processed than total)
+- Verify `CancelActiveUpdate()` is safe when no cycle is active
+**Files**: `backend/internal/scheduler/scheduler_test.go` (append)
+**Acceptance**: `go test ./internal/scheduler/ -run TestCancelActiveUpdate -v -timeout=5s` passes
+
+### 7. UpdateContainerCounts store update test
+**What**: Test `StateManager.UpdateContainerCounts()`:
+- Set up store with a stack at a known path
+- Create a `stubComposeRunner` whose `ComposePs` returns N containers (e.g. 2 running, 1 exited)
+- Call `UpdateContainerCounts`
+- Verify `store.Get().Stacks[i].ContainersRunning` and `ContainersTotal` match expected values
+- Test with `ComposePs` returning error → counts not updated, no panic
+- Test with nil store snapshot → no panic
+**Files**: `backend/internal/reconcile/state_manager_test.go` (new, package `reconcile_test`)
+**Acceptance**: `go test ./internal/reconcile/ -run TestUpdateContainerCounts -v` passes with ≥3 subtests
+
+### 8. AllLabelKeys completeness test
+**What**: Test `AllLabelKeys()`:
+- Returns exactly 8 keys
+- Contains every `Label*` constant defined in `labels.go`
+- No duplicates
+**Files**: `backend/internal/reconcile/labels_test.go` (same file as task 4)
+**Acceptance**: `go test ./internal/reconcile/ -run TestAllLabelKeys -v` passes
+
+### Verification
+- All tests pass: `cd backend && go test ./internal/reconcile/... ./internal/scheduler/... -count=1`
+- No regressions: existing tests in `reconcile_test.go`, `extract_test.go`, `metadata_test.go`, `scheduler_test.go`, and `client_test.go` continue to pass
+- Race detector: `go test -race ./internal/reconcile/... ./internal/scheduler/...`

--- a/backend/cmd/docker-cd/main.go
+++ b/backend/cmd/docker-cd/main.go
@@ -82,6 +82,13 @@ func main() {
 
 	runner := &docker.ExecRunner{}
 
+	// Initialize Docker SDK client
+	sdkClient, err := docker.NewSDKClient(cfg.DockerSocket)
+	if err != nil {
+		logger.Error("failed to create Docker SDK client", "error", err)
+		os.Exit(1)
+	}
+
 	// Initialize desired-state refresh pipeline
 	store := desiredstate.NewStore()
 	broadcaster := desiredstate.NewBroadcaster()
@@ -102,7 +109,7 @@ func main() {
 		DriftPolicy:    cfg.DriftPolicy,
 		MaxConcurrency: 1,
 	}
-	dockerClient := docker.NewClient(runner, cfg.DockerSocket)
+	dockerClient := docker.NewClient(sdkClient)
 	composeRunner := reconcile.NewDockerComposeRunner(runner, cfg.DockerSocket)
 	inspector := reconcile.NewDockerContainerInspector(dockerClient)
 	ackStore := reconcile.NewAckStore()
@@ -148,7 +155,7 @@ func main() {
 	// Start background refresh loop
 	go refreshSvc.Start(ctx)
 
-	router := handler.NewRouter(runner, cfg, refreshSvc, store, ackStore, reconciler, schedulerSvc, broadcaster)
+	router := handler.NewRouter(cfg, refreshSvc, store, ackStore, reconciler, schedulerSvc, sdkClient, broadcaster)
 
 	addr := fmt.Sprintf(":%d", cfg.Port)
 	logger.Info("http server starting", "addr", addr)

--- a/backend/internal/docker/client.go
+++ b/backend/internal/docker/client.go
@@ -2,25 +2,22 @@ package docker
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
 )
 
-// Client queries the Docker engine via the CLI.
+// Client queries the Docker engine via the SDK.
 type Client struct {
-	Runner CommandRunner
-	Socket string
+	API DockerAPI // SDK client for container/image operations
 }
 
-// NewClient creates a Client that talks to Docker via the given socket path or host URL.
-// The socket can be a Unix socket path (e.g. "/var/run/docker.sock"),
-// a full URL (e.g. "tcp://host:port" or "unix:///path"), or empty
-// to rely on the DOCKER_HOST environment variable.
-func NewClient(runner CommandRunner, socket string) *Client {
-	return &Client{Runner: runner, Socket: socket}
+// NewClient creates a Client that talks to Docker via the SDK.
+func NewClient(api DockerAPI) *Client {
+	return &Client{API: api}
 }
 
 // HostArgs returns the -H flag arguments for docker CLI commands.
@@ -37,24 +34,13 @@ func HostArgs(socket string) []string {
 
 // ContainerCount returns the number of currently running containers.
 func (c *Client) ContainerCount(ctx context.Context) (Status, error) {
-	// Use "docker ps -q" to list running container IDs, then count lines.
-	args := append(HostArgs(c.Socket), "ps", "-q")
-	out, err := c.Runner.Run(ctx, "docker", args...)
+	containers, err := c.API.ContainerList(ctx, container.ListOptions{})
 	if err != nil {
-		return Status{}, fmt.Errorf("docker CLI error: %w", err)
+		return Status{}, fmt.Errorf("docker API error: %w", err)
 	}
-
-	lines := strings.TrimSpace(string(out))
-	count := 0
-	if lines != "" {
-		count = len(strings.Split(lines, "\n"))
-	}
-
-	// Validate that the count is a reasonable number.
-	_ = strconv.Itoa(count)
 
 	return Status{
-		RunningContainers: count,
+		RunningContainers: len(containers),
 		RetrievedAt:       time.Now(),
 	}, nil
 }
@@ -68,62 +54,28 @@ type ContainerLabels struct {
 
 // ListContainersWithLabel lists running containers that have the given label key set.
 // Returns container ID, name, and all labels for each matching container.
-// Uses a two-step approach: docker ps to get container IDs, then docker inspect
-// for reliable JSON label parsing (avoids issues with comma-separated label output).
 func (c *Client) ListContainersWithLabel(ctx context.Context, labelKey string) ([]ContainerLabels, error) {
-	// Step 1: Get container IDs with the label filter
-	args := append(HostArgs(c.Socket),
-		"ps", "-q", "--no-trunc",
-		"--filter", "label="+labelKey,
-	)
-	out, err := c.Runner.Run(ctx, "docker", args...)
+	containers, err := c.API.ContainerList(ctx, container.ListOptions{
+		Filters: filters.NewArgs(filters.Arg("label", labelKey)),
+	})
 	if err != nil {
-		return nil, fmt.Errorf("docker CLI error: %w", err)
+		return nil, fmt.Errorf("docker API error: %w", err)
 	}
 
-	ids := strings.TrimSpace(string(out))
-	if ids == "" {
+	if len(containers) == 0 {
 		return nil, nil
 	}
 
-	containerIDs := strings.Split(ids, "\n")
-
-	// Step 2: Inspect containers for reliable label extraction
-	inspectArgs := append(HostArgs(c.Socket),
-		"inspect",
-		"--format", "{{json .}}",
-	)
-	inspectArgs = append(inspectArgs, containerIDs...)
-
-	inspectOut, err := c.Runner.Run(ctx, "docker", inspectArgs...)
-	if err != nil {
-		return nil, fmt.Errorf("docker inspect error: %w", err)
-	}
-
-	var result []ContainerLabels
-	// docker inspect with multiple IDs outputs one JSON object per line
-	for _, line := range strings.Split(strings.TrimSpace(string(inspectOut)), "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
+	result := make([]ContainerLabels, 0, len(containers))
+	for _, c := range containers {
+		name := ""
+		if len(c.Names) > 0 {
+			name = strings.TrimPrefix(c.Names[0], "/")
 		}
-
-		var info struct {
-			ID     string `json:"Id"`
-			Name   string `json:"Name"`
-			Config struct {
-				Labels map[string]string `json:"Labels"`
-			} `json:"Config"`
-		}
-		if err := json.Unmarshal([]byte(line), &info); err != nil {
-			continue // skip unparseable entries
-		}
-
-		name := strings.TrimPrefix(info.Name, "/")
 		result = append(result, ContainerLabels{
-			ContainerID:   info.ID,
+			ContainerID:   c.ID,
 			ContainerName: name,
-			Labels:        info.Config.Labels,
+			Labels:        c.Labels,
 		})
 	}
 	return result, nil

--- a/backend/internal/docker/client_test.go
+++ b/backend/internal/docker/client_test.go
@@ -3,44 +3,70 @@ package docker_test
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/image"
 	"github.com/lucasreiners/docker-cd/internal/docker"
 )
 
-type stubRunner struct {
-	output []byte
-	err    error
+// mockDockerAPI implements docker.DockerAPI for unit tests.
+type mockDockerAPI struct {
+	containerListFn       func(ctx context.Context, options container.ListOptions) ([]types.Container, error)
+	containerInspectFn    func(ctx context.Context, containerID string) (types.ContainerJSON, error)
+	imageInspectWithRawFn func(ctx context.Context, imageID string) (types.ImageInspect, []byte, error)
+	imagePullFn           func(ctx context.Context, refStr string, options image.PullOptions) (io.ReadCloser, error)
+	imagesPruneFn         func(ctx context.Context, pruneFilters filters.Args) (image.PruneReport, error)
 }
 
-func (s *stubRunner) Run(_ context.Context, _ string, _ ...string) ([]byte, error) {
-	return s.output, s.err
-}
-
-// multiStubRunner returns different outputs for sequential calls.
-type multiStubRunner struct {
-	outputs [][]byte
-	errs    []error
-	call    int
-}
-
-func (m *multiStubRunner) Run(_ context.Context, _ string, _ ...string) ([]byte, error) {
-	i := m.call
-	m.call++
-	if i >= len(m.outputs) {
-		return nil, fmt.Errorf("unexpected call %d", i)
+func (m *mockDockerAPI) ContainerList(ctx context.Context, options container.ListOptions) ([]types.Container, error) {
+	if m.containerListFn != nil {
+		return m.containerListFn(ctx, options)
 	}
-	var err error
-	if i < len(m.errs) {
-		err = m.errs[i]
-	}
-	return m.outputs[i], err
+	return nil, nil
 }
+
+func (m *mockDockerAPI) ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error) {
+	if m.containerInspectFn != nil {
+		return m.containerInspectFn(ctx, containerID)
+	}
+	return types.ContainerJSON{}, nil
+}
+
+func (m *mockDockerAPI) ImageInspectWithRaw(ctx context.Context, imageID string) (types.ImageInspect, []byte, error) {
+	if m.imageInspectWithRawFn != nil {
+		return m.imageInspectWithRawFn(ctx, imageID)
+	}
+	return types.ImageInspect{}, nil, nil
+}
+
+func (m *mockDockerAPI) ImagePull(ctx context.Context, refStr string, options image.PullOptions) (io.ReadCloser, error) {
+	if m.imagePullFn != nil {
+		return m.imagePullFn(ctx, refStr, options)
+	}
+	return io.NopCloser(strings.NewReader("")), nil
+}
+
+func (m *mockDockerAPI) ImagesPrune(ctx context.Context, pruneFilters filters.Args) (image.PruneReport, error) {
+	if m.imagesPruneFn != nil {
+		return m.imagesPruneFn(ctx, pruneFilters)
+	}
+	return image.PruneReport{}, nil
+}
+
+// --- ContainerCount tests (now SDK-based) ---
 
 func TestContainerCount_ThreeRunning(t *testing.T) {
-	runner := &stubRunner{output: []byte("abc123\ndef456\nghi789\n")}
-	client := docker.NewClient(runner, "/var/run/docker.sock")
+	api := &mockDockerAPI{
+		containerListFn: func(_ context.Context, _ container.ListOptions) ([]types.Container, error) {
+			return []types.Container{{ID: "abc"}, {ID: "def"}, {ID: "ghi"}}, nil
+		},
+	}
+	client := docker.NewClient(api)
 
 	status, err := client.ContainerCount(context.Background())
 	if err != nil {
@@ -52,8 +78,12 @@ func TestContainerCount_ThreeRunning(t *testing.T) {
 }
 
 func TestContainerCount_ZeroRunning(t *testing.T) {
-	runner := &stubRunner{output: []byte("")}
-	client := docker.NewClient(runner, "/var/run/docker.sock")
+	api := &mockDockerAPI{
+		containerListFn: func(_ context.Context, _ container.ListOptions) ([]types.Container, error) {
+			return nil, nil
+		},
+	}
+	client := docker.NewClient(api)
 
 	status, err := client.ContainerCount(context.Background())
 	if err != nil {
@@ -65,8 +95,12 @@ func TestContainerCount_ZeroRunning(t *testing.T) {
 }
 
 func TestContainerCount_OneRunning(t *testing.T) {
-	runner := &stubRunner{output: []byte("abc123\n")}
-	client := docker.NewClient(runner, "/var/run/docker.sock")
+	api := &mockDockerAPI{
+		containerListFn: func(_ context.Context, _ container.ListOptions) ([]types.Container, error) {
+			return []types.Container{{ID: "abc"}}, nil
+		},
+	}
+	client := docker.NewClient(api)
 
 	status, err := client.ContainerCount(context.Background())
 	if err != nil {
@@ -77,22 +111,30 @@ func TestContainerCount_OneRunning(t *testing.T) {
 	}
 }
 
-func TestContainerCount_CLIError(t *testing.T) {
-	runner := &stubRunner{output: []byte("permission denied"), err: fmt.Errorf("exit status 1")}
-	client := docker.NewClient(runner, "/var/run/docker.sock")
+func TestContainerCount_APIError(t *testing.T) {
+	api := &mockDockerAPI{
+		containerListFn: func(_ context.Context, _ container.ListOptions) ([]types.Container, error) {
+			return nil, fmt.Errorf("connection refused")
+		},
+	}
+	client := docker.NewClient(api)
 
 	_, err := client.ContainerCount(context.Background())
 	if err == nil {
-		t.Fatal("expected error from CLI failure, got nil")
+		t.Fatal("expected error from API failure, got nil")
 	}
-	if !strings.Contains(err.Error(), "docker CLI error") {
-		t.Errorf("expected error to contain 'docker CLI error', got %q", err.Error())
+	if !strings.Contains(err.Error(), "docker API error") {
+		t.Errorf("expected error to contain 'docker API error', got %q", err.Error())
 	}
 }
 
 func TestContainerCount_RetrievedAtSet(t *testing.T) {
-	runner := &stubRunner{output: []byte("abc\n")}
-	client := docker.NewClient(runner, "/var/run/docker.sock")
+	api := &mockDockerAPI{
+		containerListFn: func(_ context.Context, _ container.ListOptions) ([]types.Container, error) {
+			return []types.Container{{ID: "abc"}}, nil
+		},
+	}
+	client := docker.NewClient(api)
 
 	status, err := client.ContainerCount(context.Background())
 	if err != nil {
@@ -103,9 +145,15 @@ func TestContainerCount_RetrievedAtSet(t *testing.T) {
 	}
 }
 
+// --- ListContainersWithLabel tests (now SDK-based) ---
+
 func TestListContainersWithLabel_Empty(t *testing.T) {
-	runner := &stubRunner{output: []byte("")}
-	client := docker.NewClient(runner, "/var/run/docker.sock")
+	api := &mockDockerAPI{
+		containerListFn: func(_ context.Context, _ container.ListOptions) ([]types.Container, error) {
+			return nil, nil
+		},
+	}
+	client := docker.NewClient(api)
 
 	containers, err := client.ListContainersWithLabel(context.Background(), "com.docker-cd.stack.path")
 	if err != nil {
@@ -117,12 +165,18 @@ func TestListContainersWithLabel_Empty(t *testing.T) {
 }
 
 func TestListContainersWithLabel_SingleContainer(t *testing.T) {
-	psOutput := "abc123\n"
-	inspectOutput := `{"Id":"abc123","Name":"/my-app","Config":{"Labels":{"com.docker-cd.stack.path":"app1","com.docker-cd.sync.status":"synced"}}}` + "\n"
-	runner := &multiStubRunner{
-		outputs: [][]byte{[]byte(psOutput), []byte(inspectOutput)},
+	api := &mockDockerAPI{
+		containerListFn: func(_ context.Context, _ container.ListOptions) ([]types.Container, error) {
+			return []types.Container{
+				{
+					ID:     "abc123",
+					Names:  []string{"/my-app"},
+					Labels: map[string]string{"com.docker-cd.stack.path": "app1", "com.docker-cd.sync.status": "synced"},
+				},
+			}, nil
+		},
 	}
-	client := docker.NewClient(runner, "/var/run/docker.sock")
+	client := docker.NewClient(api)
 
 	containers, err := client.ListContainersWithLabel(context.Background(), "com.docker-cd.stack.path")
 	if err != nil {
@@ -146,13 +200,15 @@ func TestListContainersWithLabel_SingleContainer(t *testing.T) {
 }
 
 func TestListContainersWithLabel_MultipleContainers(t *testing.T) {
-	psOutput := "abc123\nabc456\n"
-	inspectOutput := `{"Id":"abc123","Name":"/app1-web","Config":{"Labels":{"com.docker-cd.stack.path":"app1"}}}` + "\n" +
-		`{"Id":"abc456","Name":"/app2-web","Config":{"Labels":{"com.docker-cd.stack.path":"app2"}}}` + "\n"
-	runner := &multiStubRunner{
-		outputs: [][]byte{[]byte(psOutput), []byte(inspectOutput)},
+	api := &mockDockerAPI{
+		containerListFn: func(_ context.Context, _ container.ListOptions) ([]types.Container, error) {
+			return []types.Container{
+				{ID: "abc123", Names: []string{"/app1-web"}, Labels: map[string]string{"com.docker-cd.stack.path": "app1"}},
+				{ID: "abc456", Names: []string{"/app2-web"}, Labels: map[string]string{"com.docker-cd.stack.path": "app2"}},
+			}, nil
+		},
 	}
-	client := docker.NewClient(runner, "/var/run/docker.sock")
+	client := docker.NewClient(api)
 
 	containers, err := client.ListContainersWithLabel(context.Background(), "com.docker-cd.stack.path")
 	if err != nil {
@@ -163,54 +219,25 @@ func TestListContainersWithLabel_MultipleContainers(t *testing.T) {
 	}
 }
 
-func TestListContainersWithLabel_InvalidJSON(t *testing.T) {
-	psOutput := "abc123\n"
-	inspectOutput := "not valid JSON\n"
-	runner := &multiStubRunner{
-		outputs: [][]byte{[]byte(psOutput), []byte(inspectOutput)},
+func TestListContainersWithLabel_APIError(t *testing.T) {
+	api := &mockDockerAPI{
+		containerListFn: func(_ context.Context, _ container.ListOptions) ([]types.Container, error) {
+			return nil, fmt.Errorf("connection refused")
+		},
 	}
-	client := docker.NewClient(runner, "/var/run/docker.sock")
-
-	containers, err := client.ListContainersWithLabel(context.Background(), "com.docker-cd.stack.path")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(containers) != 0 {
-		t.Errorf("expected 0 containers (invalid JSON skipped), got %d", len(containers))
-	}
-}
-
-func TestListContainersWithLabel_InspectError(t *testing.T) {
-	psOutput := "abc123\n"
-	runner := &multiStubRunner{
-		outputs: [][]byte{[]byte(psOutput), []byte("inspect error")},
-		errs:    []error{nil, fmt.Errorf("exit status 1")},
-	}
-	client := docker.NewClient(runner, "/var/run/docker.sock")
+	client := docker.NewClient(api)
 
 	_, err := client.ListContainersWithLabel(context.Background(), "com.docker-cd.stack.path")
 	if err == nil {
-		t.Fatal("expected error from inspect failure, got nil")
+		t.Fatal("expected error from API failure, got nil")
 	}
-	if !strings.Contains(err.Error(), "docker inspect error") {
-		t.Errorf("expected docker inspect error, got %q", err.Error())
-	}
-}
-
-func TestListContainersWithLabel_CLIError(t *testing.T) {
-	runner := &stubRunner{output: []byte("error"), err: fmt.Errorf("exit status 1")}
-	client := docker.NewClient(runner, "/var/run/docker.sock")
-
-	_, err := client.ListContainersWithLabel(context.Background(), "com.docker-cd.stack.path")
-	if err == nil {
-		t.Fatal("expected error from CLI failure, got nil")
-	}
-	if !strings.Contains(err.Error(), "docker CLI error") {
-		t.Errorf("expected docker CLI error, got %q", err.Error())
+	if !strings.Contains(err.Error(), "docker API error") {
+		t.Errorf("expected docker API error, got %q", err.Error())
 	}
 }
 
-// HostArgs tests
+// --- HostArgs tests (unchanged) ---
+
 func TestHostArgs_EmptySocket(t *testing.T) {
 	args := docker.HostArgs("")
 	if args != nil {
@@ -242,34 +269,143 @@ func TestHostArgs_UnixURL(t *testing.T) {
 	}
 }
 
-// Image operations tests
-func TestPullImages_Success(t *testing.T) {
-	runner := &stubRunner{output: []byte("")}
-	client := docker.NewClient(runner, "/var/run/docker.sock")
+// --- PullImages tests (now SDK-based) ---
 
-	err := client.PullImages(context.Background(), "myproject", "/path/to/compose.yml", "")
+func TestPullImages_Success(t *testing.T) {
+	api := &mockDockerAPI{
+		imagePullFn: func(_ context.Context, refStr string, _ image.PullOptions) (io.ReadCloser, error) {
+			stream := `{"status":"Pulling from library/nginx","id":"latest"}` + "\n" +
+				`{"status":"Pull complete","id":"abc123"}` + "\n"
+			return io.NopCloser(strings.NewReader(stream)), nil
+		},
+	}
+	client := docker.NewClient(api)
+
+	var progress []docker.PullProgress
+	err := client.PullImages(context.Background(), []string{"nginx:latest"}, func(p docker.PullProgress) {
+		progress = append(progress, p)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should have at least the final "Pull complete" event
+	if len(progress) == 0 {
+		t.Fatal("expected at least one progress event")
+	}
+	last := progress[len(progress)-1]
+	if last.Status != "Pull complete" {
+		t.Errorf("expected last status 'Pull complete', got %q", last.Status)
+	}
+	if last.Image != "nginx:latest" {
+		t.Errorf("expected image 'nginx:latest', got %q", last.Image)
+	}
+	if last.Current != 1 || last.Total != 1 {
+		t.Errorf("expected 1/1, got %d/%d", last.Current, last.Total)
+	}
+}
+
+func TestPullImages_Error(t *testing.T) {
+	api := &mockDockerAPI{
+		imagePullFn: func(_ context.Context, _ string, _ image.PullOptions) (io.ReadCloser, error) {
+			return nil, fmt.Errorf("unauthorized")
+		},
+	}
+	client := docker.NewClient(api)
+
+	err := client.PullImages(context.Background(), []string{"private/image:latest"}, nil)
+	if err == nil {
+		t.Fatal("expected error from pull failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "pull private/image:latest failed") {
+		t.Errorf("expected error to contain image name, got %q", err.Error())
+	}
+}
+
+func TestPullImages_StreamError(t *testing.T) {
+	api := &mockDockerAPI{
+		imagePullFn: func(_ context.Context, _ string, _ image.PullOptions) (io.ReadCloser, error) {
+			stream := `{"error":"image not found"}` + "\n"
+			return io.NopCloser(strings.NewReader(stream)), nil
+		},
+	}
+	client := docker.NewClient(api)
+
+	err := client.PullImages(context.Background(), []string{"nonexistent:latest"}, nil)
+	if err == nil {
+		t.Fatal("expected error from stream error event")
+	}
+	if !strings.Contains(err.Error(), "image not found") {
+		t.Errorf("expected 'image not found' in error, got %q", err.Error())
+	}
+}
+
+func TestPullImages_NilCallback(t *testing.T) {
+	api := &mockDockerAPI{
+		imagePullFn: func(_ context.Context, _ string, _ image.PullOptions) (io.ReadCloser, error) {
+			stream := `{"status":"Pull complete"}` + "\n"
+			return io.NopCloser(strings.NewReader(stream)), nil
+		},
+	}
+	client := docker.NewClient(api)
+
+	err := client.PullImages(context.Background(), []string{"nginx:latest"}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
-func TestPullImages_Error(t *testing.T) {
-	runner := &stubRunner{output: []byte("pull failed"), err: fmt.Errorf("exit status 1")}
-	client := docker.NewClient(runner, "/var/run/docker.sock")
-
-	err := client.PullImages(context.Background(), "myproject", "/path/to/compose.yml", "")
-	if err == nil {
-		t.Fatal("expected error from pull failure, got nil")
+func TestPullImages_MultipleImages(t *testing.T) {
+	pullCount := 0
+	api := &mockDockerAPI{
+		imagePullFn: func(_ context.Context, refStr string, _ image.PullOptions) (io.ReadCloser, error) {
+			pullCount++
+			stream := fmt.Sprintf(`{"status":"Pull complete","id":"%s"}`, refStr) + "\n"
+			return io.NopCloser(strings.NewReader(stream)), nil
+		},
 	}
-	if !strings.Contains(err.Error(), "docker compose pull failed") {
-		t.Errorf("expected error to contain 'docker compose pull failed', got %q", err.Error())
+	client := docker.NewClient(api)
+
+	var events []docker.PullProgress
+	err := client.PullImages(context.Background(), []string{"nginx:latest", "redis:7"}, func(p docker.PullProgress) {
+		events = append(events, p)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pullCount != 2 {
+		t.Errorf("expected 2 pull calls, got %d", pullCount)
+	}
+	// Check the final events have correct Current/Total
+	found := map[string]bool{}
+	for _, e := range events {
+		if e.Status == "Pull complete" {
+			found[e.Image] = true
+			if e.Total != 2 {
+				t.Errorf("expected total=2, got %d for %s", e.Total, e.Image)
+			}
+		}
+	}
+	if !found["nginx:latest"] || !found["redis:7"] {
+		t.Errorf("expected both images in progress events, got %v", found)
 	}
 }
 
+// --- PruneImages tests (now SDK-based) ---
+
 func TestPruneImages_Success(t *testing.T) {
-	output := "Deleted Images:\ndeleted: sha256:abc123\ndeleted: sha256:def456\nTotal reclaimed space: 1.234GB\n"
-	runner := &stubRunner{output: []byte(output)}
-	client := docker.NewClient(runner, "/var/run/docker.sock")
+	api := &mockDockerAPI{
+		imagesPruneFn: func(_ context.Context, _ filters.Args) (image.PruneReport, error) {
+			return image.PruneReport{
+				ImagesDeleted: []image.DeleteResponse{
+					{Deleted: "sha256:abc123"},
+					{Deleted: "sha256:def456"},
+					{Untagged: "nginx:latest"},
+				},
+				SpaceReclaimed: 1234000000, // ~1.234GB
+			}, nil
+		},
+	}
+	client := docker.NewClient(api)
 
 	removed, space, err := client.PruneImages(context.Background())
 	if err != nil {
@@ -278,16 +414,20 @@ func TestPruneImages_Success(t *testing.T) {
 	if space != "1.234GB" {
 		t.Errorf("expected space '1.234GB', got %q", space)
 	}
-	// Note: The current implementation counts both "Deleted Images:" header and "deleted:" lines
 	if removed != 3 {
-		t.Errorf("expected 3 lines counted (1 header + 2 deleted), got %d", removed)
+		t.Errorf("expected 3 images removed, got %d", removed)
 	}
 }
 
 func TestPruneImages_NoImagesRemoved(t *testing.T) {
-	output := "Total reclaimed space: 0B\n"
-	runner := &stubRunner{output: []byte(output)}
-	client := docker.NewClient(runner, "/var/run/docker.sock")
+	api := &mockDockerAPI{
+		imagesPruneFn: func(_ context.Context, _ filters.Args) (image.PruneReport, error) {
+			return image.PruneReport{
+				SpaceReclaimed: 0,
+			}, nil
+		},
+	}
+	client := docker.NewClient(api)
 
 	removed, space, err := client.PruneImages(context.Background())
 	if err != nil {
@@ -302,8 +442,12 @@ func TestPruneImages_NoImagesRemoved(t *testing.T) {
 }
 
 func TestPruneImages_Error(t *testing.T) {
-	runner := &stubRunner{output: []byte("prune failed"), err: fmt.Errorf("exit status 1")}
-	client := docker.NewClient(runner, "/var/run/docker.sock")
+	api := &mockDockerAPI{
+		imagesPruneFn: func(_ context.Context, _ filters.Args) (image.PruneReport, error) {
+			return image.PruneReport{}, fmt.Errorf("permission denied")
+		},
+	}
+	client := docker.NewClient(api)
 
 	_, _, err := client.PruneImages(context.Background())
 	if err == nil {
@@ -314,23 +458,32 @@ func TestPruneImages_Error(t *testing.T) {
 	}
 }
 
+// --- GetImageDigest tests (now SDK-based) ---
+
 func TestGetImageDigest_Success(t *testing.T) {
-	digest := "sha256:abc123def456"
-	runner := &stubRunner{output: []byte(digest + "\n")}
-	client := docker.NewClient(runner, "/var/run/docker.sock")
+	api := &mockDockerAPI{
+		imageInspectWithRawFn: func(_ context.Context, _ string) (types.ImageInspect, []byte, error) {
+			return types.ImageInspect{ID: "sha256:abc123def456"}, nil, nil
+		},
+	}
+	client := docker.NewClient(api)
 
 	result, err := client.GetImageDigest(context.Background(), "nginx:latest")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if result != digest {
-		t.Errorf("expected digest %q, got %q", digest, result)
+	if result != "sha256:abc123def456" {
+		t.Errorf("expected digest %q, got %q", "sha256:abc123def456", result)
 	}
 }
 
 func TestGetImageDigest_Error(t *testing.T) {
-	runner := &stubRunner{output: []byte("inspect failed"), err: fmt.Errorf("exit status 1")}
-	client := docker.NewClient(runner, "/var/run/docker.sock")
+	api := &mockDockerAPI{
+		imageInspectWithRawFn: func(_ context.Context, _ string) (types.ImageInspect, []byte, error) {
+			return types.ImageInspect{}, nil, fmt.Errorf("image not found")
+		},
+	}
+	client := docker.NewClient(api)
 
 	_, err := client.GetImageDigest(context.Background(), "nonexistent:image")
 	if err == nil {
@@ -339,80 +492,4 @@ func TestGetImageDigest_Error(t *testing.T) {
 	if !strings.Contains(err.Error(), "docker inspect failed") {
 		t.Errorf("expected error to contain 'docker inspect failed', got %q", err.Error())
 	}
-}
-
-// GetComposeImages tests
-
-func TestGetComposeImages_Success(t *testing.T) {
-	output := "nginx:latest\nredis:7-alpine\npostgres:16\n"
-	runner := &stubRunner{output: []byte(output)}
-	client := docker.NewClient(runner, "/var/run/docker.sock")
-
-	images, err := client.GetComposeImages(context.Background(), "myproject", "/path/to/compose.yml", "/work")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(images) != 3 {
-		t.Fatalf("expected 3 images, got %d", len(images))
-	}
-	expected := []string{"nginx:latest", "redis:7-alpine", "postgres:16"}
-	for i, img := range images {
-		if img != expected[i] {
-			t.Errorf("image[%d]: expected %q, got %q", i, expected[i], img)
-		}
-	}
-}
-
-func TestGetComposeImages_EmptyOutput(t *testing.T) {
-	runner := &stubRunner{output: []byte("")}
-	client := docker.NewClient(runner, "/var/run/docker.sock")
-
-	images, err := client.GetComposeImages(context.Background(), "myproject", "/path/to/compose.yml", "")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(images) != 0 {
-		t.Errorf("expected 0 images, got %d", len(images))
-	}
-}
-
-func TestGetComposeImages_Error(t *testing.T) {
-	runner := &stubRunner{output: []byte("config failed"), err: fmt.Errorf("exit status 1")}
-	client := docker.NewClient(runner, "/var/run/docker.sock")
-
-	_, err := client.GetComposeImages(context.Background(), "myproject", "/path/to/compose.yml", "")
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !strings.Contains(err.Error(), "docker compose config --images failed") {
-		t.Errorf("expected error to contain 'docker compose config --images failed', got %q", err.Error())
-	}
-}
-
-func TestGetComposeImages_WithWorkDir(t *testing.T) {
-	var capturedArgs []string
-	runner := &argCapturingRunner{output: []byte("nginx:latest\n"), capture: func(args []string) { capturedArgs = args }}
-	client := docker.NewClient(runner, "/var/run/docker.sock")
-
-	_, err := client.GetComposeImages(context.Background(), "myproject", "/path/to/compose.yml", "/my/workdir")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	// Verify --project-directory was passed
-	if !strings.Contains(strings.Join(capturedArgs, " "), "--project-directory") {
-		t.Error("expected --project-directory in args when workDir is set")
-	}
-}
-
-// argCapturingRunner is a CommandRunner that captures the args passed to Run.
-type argCapturingRunner struct {
-	output  []byte
-	capture func(args []string)
-}
-
-func (r *argCapturingRunner) Run(_ context.Context, _ string, args ...string) ([]byte, error) {
-	if r.capture != nil {
-		r.capture(args)
-	}
-	return r.output, nil
 }

--- a/backend/internal/docker/images.go
+++ b/backend/internal/docker/images.go
@@ -2,127 +2,148 @@ package docker
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
-	"strings"
+	"io"
+	"time"
+
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/image"
 )
+
+// PullProgress represents progress information for an image pull operation.
+type PullProgress struct {
+	Image    string `json:"image"`
+	Status   string `json:"status"`
+	Progress string `json:"progress"`
+	Current  int    `json:"current"`
+	Total    int    `json:"total"`
+}
+
+// PullProgressFn is a callback invoked during image pulls with progress updates.
+type PullProgressFn func(PullProgress)
 
 // ImageOperations defines operations for managing Docker images.
 type ImageOperations interface {
-	// PullImages pulls all images for a compose project
-	PullImages(ctx context.Context, projectName, composeFile, workDir string) error
+	// PullImages pulls the given images via the Docker SDK.
+	// onProgress is called with throttled progress updates; nil is safe.
+	PullImages(ctx context.Context, images []string, onProgress PullProgressFn) error
 
 	// PruneImages removes all unused and dangling images system-wide
 	PruneImages(ctx context.Context) (imagesRemoved int, spaceReclaimed string, err error)
 
 	// GetImageDigest returns the digest of an image
 	GetImageDigest(ctx context.Context, imageName string) (string, error)
-
-	// GetComposeImages returns the list of images referenced by a compose file.
-	GetComposeImages(ctx context.Context, projectName, composeFile, workDir string) ([]string, error)
 }
 
-// PullImages pulls all images defined in a compose file.
-// Uses "docker compose pull" to handle all images in the compose file.
-func (c *Client) PullImages(ctx context.Context, projectName, composeFile, workDir string) error {
-	args := append(HostArgs(c.Socket), "compose", "-p", projectName)
-	if workDir != "" {
-		args = append(args, "--project-directory", workDir)
-	}
-	args = append(args, "-f", composeFile, "pull")
+// pullStreamEvent represents a single JSON event from the Docker image pull stream.
+type pullStreamEvent struct {
+	Status   string `json:"status"`
+	Progress string `json:"progress"`
+	ID       string `json:"id"`
+	Error    string `json:"error"`
+}
 
-	out, err := c.Runner.Run(ctx, "docker", args...)
-	if err != nil {
-		output := strings.TrimSpace(string(out))
-		if output != "" {
-			return fmt.Errorf("docker compose pull failed: %s: %w", truncateOutput(output, 2000), err)
+// PullImages pulls the given images individually via the Docker SDK.
+// Progress is reported through onProgress (throttled to ~500ms per image). Nil callback is safe.
+func (c *Client) PullImages(ctx context.Context, images []string, onProgress PullProgressFn) error {
+	total := len(images)
+	for i, img := range images {
+		if err := c.pullImage(ctx, img, i+1, total, onProgress); err != nil {
+			return fmt.Errorf("pull %s failed: %w", img, err)
 		}
-		return fmt.Errorf("docker compose pull failed: %w", err)
 	}
-
 	return nil
 }
 
-func truncateOutput(output string, maxLen int) string {
-	if maxLen <= 0 || len(output) <= maxLen {
-		return output
-	}
-	return output[:maxLen] + "..."
-}
-
-// GetComposeImages returns the list of images referenced by a compose file.
-// Uses "docker compose config --images" to extract image names.
-func (c *Client) GetComposeImages(ctx context.Context, projectName, composeFile, workDir string) ([]string, error) {
-	args := append(HostArgs(c.Socket), "compose", "-p", projectName)
-	if workDir != "" {
-		args = append(args, "--project-directory", workDir)
-	}
-	args = append(args, "-f", composeFile, "config", "--images")
-
-	out, err := c.Runner.Run(ctx, "docker", args...)
+func (c *Client) pullImage(ctx context.Context, img string, current, total int, onProgress PullProgressFn) error {
+	reader, err := c.API.ImagePull(ctx, img, image.PullOptions{})
 	if err != nil {
-		output := strings.TrimSpace(string(out))
-		if output != "" {
-			return nil, fmt.Errorf("docker compose config --images failed: %s: %w", truncateOutput(output, 2000), err)
+		return err
+	}
+	defer reader.Close()
+
+	decoder := json.NewDecoder(reader)
+	var lastNotify time.Time
+
+	for {
+		var event pullStreamEvent
+		if err := decoder.Decode(&event); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
 		}
-		return nil, fmt.Errorf("docker compose config --images failed: %w", err)
+		if event.Error != "" {
+			return fmt.Errorf("%s", event.Error)
+		}
+		if onProgress != nil && time.Since(lastNotify) >= 500*time.Millisecond {
+			lastNotify = time.Now()
+			onProgress(PullProgress{
+				Image:    img,
+				Status:   event.Status,
+				Progress: event.Progress,
+				Current:  current,
+				Total:    total,
+			})
+		}
 	}
 
-	var images []string
-	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		line = strings.TrimSpace(line)
-		if line != "" {
-			images = append(images, line)
-		}
+	// Send a final "complete" progress event for this image
+	if onProgress != nil {
+		onProgress(PullProgress{
+			Image:   img,
+			Status:  "Pull complete",
+			Current: current,
+			Total:   total,
+		})
 	}
-	return images, nil
+	return nil
 }
 
 // PruneImages removes all unused and dangling images system-wide.
 // Returns the number of images removed and space reclaimed.
 func (c *Client) PruneImages(ctx context.Context) (int, string, error) {
-	args := append(HostArgs(c.Socket),
-		"image", "prune", "-af")
-
-	out, err := c.Runner.Run(ctx, "docker", args...)
+	report, err := c.API.ImagesPrune(ctx, filters.NewArgs(filters.Arg("dangling", "false")))
 	if err != nil {
 		return 0, "", fmt.Errorf("docker image prune failed: %w", err)
 	}
 
-	// Parse output for space reclaimed
-	// Expected format: "Total reclaimed space: 1.234GB"
-	output := string(out)
-	spaceReclaimed := "0B"
-	imagesRemoved := 0
-
-	for _, line := range strings.Split(output, "\n") {
-		if strings.HasPrefix(line, "Total reclaimed space:") {
-			parts := strings.SplitN(line, ":", 2)
-			if len(parts) == 2 {
-				spaceReclaimed = strings.TrimSpace(parts[1])
-			}
-		}
-		if strings.HasPrefix(line, "Deleted Images:") || strings.Contains(line, "deleted:") {
-			// Count number of deleted lines
-			imagesRemoved++
-		}
-	}
+	imagesRemoved := len(report.ImagesDeleted)
+	spaceReclaimed := formatBytes(report.SpaceReclaimed)
 
 	return imagesRemoved, spaceReclaimed, nil
+}
+
+// formatBytes converts bytes to a human-readable string matching Docker CLI output format.
+func formatBytes(bytes uint64) string {
+	if bytes == 0 {
+		return "0B"
+	}
+	const (
+		kb = 1000
+		mb = 1000 * kb
+		gb = 1000 * mb
+	)
+	switch {
+	case bytes >= gb:
+		return fmt.Sprintf("%.3fGB", float64(bytes)/float64(gb))
+	case bytes >= mb:
+		return fmt.Sprintf("%.3fMB", float64(bytes)/float64(mb))
+	case bytes >= kb:
+		return fmt.Sprintf("%.3fkB", float64(bytes)/float64(kb))
+	default:
+		return fmt.Sprintf("%dB", bytes)
+	}
 }
 
 // GetImageDigest returns the digest (SHA256 hash) of an image.
 // Returns the full digest string like "sha256:abc123..."
 func (c *Client) GetImageDigest(ctx context.Context, imageName string) (string, error) {
-	args := append(HostArgs(c.Socket),
-		"inspect",
-		"--format", "{{.Id}}",
-		imageName)
-
-	out, err := c.Runner.Run(ctx, "docker", args...)
+	inspect, _, err := c.API.ImageInspectWithRaw(ctx, imageName)
 	if err != nil {
 		return "", fmt.Errorf("docker inspect failed: %w", err)
 	}
 
-	digest := strings.TrimSpace(string(out))
-	return digest, nil
+	return inspect.ID, nil
 }

--- a/backend/internal/docker/sdk.go
+++ b/backend/internal/docker/sdk.go
@@ -1,0 +1,53 @@
+package docker
+
+import (
+	"context"
+	"io"
+	"strings"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/client"
+)
+
+// DockerAPI abstracts the subset of the Docker SDK client used by this package.
+// Implementations include the real SDK client and test mocks.
+type DockerAPI interface {
+	ContainerList(ctx context.Context, options container.ListOptions) ([]types.Container, error)
+	ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error)
+	ImageInspectWithRaw(ctx context.Context, imageID string) (types.ImageInspect, []byte, error)
+	ImagePull(ctx context.Context, refStr string, options image.PullOptions) (io.ReadCloser, error)
+	ImagesPrune(ctx context.Context, pruneFilters filters.Args) (image.PruneReport, error)
+}
+
+// NewSDKClient creates a DockerAPI backed by the real Docker SDK.
+// The socket parameter can be:
+//   - Empty string: uses DOCKER_HOST env or default socket
+//   - A Unix socket path (e.g. "/var/run/docker.sock"): converted to "unix:///path"
+//   - A full URL (e.g. "tcp://host:port" or "unix:///path"): used as-is
+func NewSDKClient(socket string) (DockerAPI, error) {
+	opts := []client.Opt{client.WithAPIVersionNegotiation()}
+
+	host := socketToHost(socket)
+	if host != "" {
+		opts = append(opts, client.WithHost(host))
+	} else {
+		opts = append(opts, client.FromEnv)
+	}
+
+	return client.NewClientWithOpts(opts...)
+}
+
+// socketToHost converts a socket string to a Docker host URL.
+// Returns empty string if the socket is empty (use default/env).
+func socketToHost(socket string) string {
+	if socket == "" {
+		return ""
+	}
+	if strings.HasPrefix(socket, "tcp://") || strings.HasPrefix(socket, "unix://") {
+		return socket
+	}
+	return "unix://" + socket
+}

--- a/backend/internal/http/events_test.go
+++ b/backend/internal/http/events_test.go
@@ -18,11 +18,11 @@ import (
 )
 
 // setupRouterWithBroadcaster creates a router with SSE broadcaster wired up.
-func setupRouterWithBroadcaster(runner handler.CommandRunner, cfg config.Config, store *desiredstate.Store, broadcaster *desiredstate.Broadcaster) *gin.Engine {
+func setupRouterWithBroadcaster(cfg config.Config, store *desiredstate.Store, broadcaster *desiredstate.Broadcaster) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	queue := refresh.NewQueue()
 	svc := refresh.NewService(cfg, store, queue, nil)
-	return handler.NewRouter(runner, cfg, svc, store, nil, nil, nil, broadcaster)
+	return handler.NewRouter(cfg, svc, store, nil, nil, nil, nil, broadcaster)
 }
 
 // sseEvent holds a parsed SSE event.
@@ -62,7 +62,6 @@ func readSSEEvent(t *testing.T, scanner *bufio.Scanner) sseEvent {
 // TestEventsSSE_InitialSnapshot verifies the /api/events endpoint sends
 // SSE headers and an initial stack.snapshot event containing all current stacks.
 func TestEventsSSE_InitialSnapshot(t *testing.T) {
-	runner := &stubRunner{output: []byte("a\n")}
 	cfg := config.Config{Port: 8080, ProjectName: "Docker-CD", DockerSocket: "/var/run/docker.sock"}
 
 	store := desiredstate.NewStore()
@@ -76,7 +75,7 @@ func TestEventsSSE_InitialSnapshot(t *testing.T) {
 	})
 
 	broadcaster := desiredstate.NewBroadcaster()
-	router := setupRouterWithBroadcaster(runner, cfg, store, broadcaster)
+	router := setupRouterWithBroadcaster(cfg, store, broadcaster)
 
 	ts := httptest.NewServer(router)
 	defer ts.Close()
@@ -141,7 +140,6 @@ func TestEventsSSE_InitialSnapshot(t *testing.T) {
 // TestEventsSSE_UpsertEvent verifies that publishing a stack.upsert event
 // reaches connected SSE clients.
 func TestEventsSSE_UpsertEvent(t *testing.T) {
-	runner := &stubRunner{output: []byte("a\n")}
 	cfg := config.Config{Port: 8080, ProjectName: "Docker-CD", DockerSocket: "/var/run/docker.sock"}
 
 	store := desiredstate.NewStore()
@@ -151,7 +149,7 @@ func TestEventsSSE_UpsertEvent(t *testing.T) {
 	})
 
 	broadcaster := desiredstate.NewBroadcaster()
-	router := setupRouterWithBroadcaster(runner, cfg, store, broadcaster)
+	router := setupRouterWithBroadcaster(cfg, store, broadcaster)
 
 	ts := httptest.NewServer(router)
 	defer ts.Close()
@@ -205,12 +203,11 @@ func TestEventsSSE_UpsertEvent(t *testing.T) {
 
 // TestEventsSSE_EmptyStoreSnapshot verifies empty store sends empty records array.
 func TestEventsSSE_EmptyStoreSnapshot(t *testing.T) {
-	runner := &stubRunner{output: []byte("a\n")}
 	cfg := config.Config{Port: 8080, ProjectName: "Docker-CD", DockerSocket: "/var/run/docker.sock"}
 
 	store := desiredstate.NewStore()
 	broadcaster := desiredstate.NewBroadcaster()
-	router := setupRouterWithBroadcaster(runner, cfg, store, broadcaster)
+	router := setupRouterWithBroadcaster(cfg, store, broadcaster)
 
 	ts := httptest.NewServer(router)
 	defer ts.Close()

--- a/backend/internal/http/handler.go
+++ b/backend/internal/http/handler.go
@@ -21,19 +21,17 @@ import (
 	"github.com/lucasreiners/docker-cd/internal/render"
 )
 
-// CommandRunner abstracts command execution so handler tests can stub it.
-type CommandRunner interface {
-	Run(ctx context.Context, name string, args ...string) ([]byte, error)
-}
-
 // UpdateTrigger abstracts the scheduler's manual trigger capability.
 type UpdateTrigger interface {
 	TriggerUpdateCycle(ctx context.Context) error
 	GetUpdateStatus() interface{}
 }
 
+// DockerAPI abstracts the Docker SDK client for container operations.
+type DockerAPI = docker.DockerAPI
+
 // RootHandler returns a Gin handler that renders the status page.
-func RootHandler(runner CommandRunner, cfg config.Config) gin.HandlerFunc {
+func RootHandler(cfg config.Config, api DockerAPI) gin.HandlerFunc {
 	// Build repo info from config (never includes token)
 	var repo *render.RepoInfo
 	if cfg.GitRepoURL != "" {
@@ -45,7 +43,7 @@ func RootHandler(runner CommandRunner, cfg config.Config) gin.HandlerFunc {
 	}
 
 	return func(c *gin.Context) {
-		client := docker.NewClient(runner, cfg.DockerSocket)
+		client := docker.NewClient(api)
 		status, err := client.ContainerCount(c.Request.Context())
 		if err != nil {
 			c.String(http.StatusInternalServerError, err.Error())

--- a/backend/internal/http/handler_test.go
+++ b/backend/internal/http/handler_test.go
@@ -6,11 +6,16 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/image"
 	"github.com/gin-gonic/gin"
 	"github.com/lucasreiners/docker-cd/internal/config"
 	"github.com/lucasreiners/docker-cd/internal/desiredstate"
@@ -19,25 +24,43 @@ import (
 	"github.com/lucasreiners/docker-cd/internal/refresh"
 )
 
-type stubRunner struct {
-	output []byte
-	err    error
+// stubDockerAPI implements docker.DockerAPI for handler tests.
+type stubDockerAPI struct {
+	containers []types.Container
+	err        error
 }
 
-func (s *stubRunner) Run(_ context.Context, _ string, _ ...string) ([]byte, error) {
-	return s.output, s.err
+func (s *stubDockerAPI) ContainerList(_ context.Context, _ container.ListOptions) ([]types.Container, error) {
+	return s.containers, s.err
+}
+func (s *stubDockerAPI) ContainerInspect(_ context.Context, _ string) (types.ContainerJSON, error) {
+	return types.ContainerJSON{}, nil
+}
+func (s *stubDockerAPI) ImageInspectWithRaw(_ context.Context, _ string) (types.ImageInspect, []byte, error) {
+	return types.ImageInspect{}, nil, nil
+}
+func (s *stubDockerAPI) ImagePull(_ context.Context, _ string, _ image.PullOptions) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader("")), nil
+}
+func (s *stubDockerAPI) ImagesPrune(_ context.Context, _ filters.Args) (image.PruneReport, error) {
+	return image.PruneReport{}, nil
 }
 
-func setupRouter(runner handler.CommandRunner, cfg config.Config) *gin.Engine {
+func setupRouter(cfg config.Config) *gin.Engine {
 	gin.SetMode(gin.TestMode)
-	return handler.NewRouter(runner, cfg, nil, nil, nil, nil, nil)
+	return handler.NewRouter(cfg, nil, nil, nil, nil, nil, nil)
+}
+
+func setupRouterWithAPI(cfg config.Config, api handler.DockerAPI) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	return handler.NewRouter(cfg, nil, nil, nil, nil, nil, api)
 }
 
 func TestRootHandler_Success(t *testing.T) {
-	runner := &stubRunner{output: []byte("a\nb\nc\n")}
+	api := &stubDockerAPI{containers: []types.Container{{ID: "a"}, {ID: "b"}, {ID: "c"}}}
 	cfg := config.Config{Port: 8080, ProjectName: "Docker-CD", DockerSocket: "/var/run/docker.sock"}
 
-	router := setupRouter(runner, cfg)
+	router := setupRouterWithAPI(cfg, api)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
@@ -57,10 +80,10 @@ func TestRootHandler_Success(t *testing.T) {
 }
 
 func TestRootHandler_DockerError(t *testing.T) {
-	runner := &stubRunner{output: []byte("permission denied"), err: fmt.Errorf("exit status 1")}
+	api := &stubDockerAPI{err: fmt.Errorf("connection refused")}
 	cfg := config.Config{Port: 8080, ProjectName: "Docker-CD", DockerSocket: "/var/run/docker.sock"}
 
-	router := setupRouter(runner, cfg)
+	router := setupRouterWithAPI(cfg, api)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
@@ -71,16 +94,16 @@ func TestRootHandler_DockerError(t *testing.T) {
 	}
 
 	body := w.Body.String()
-	if !strings.Contains(body, "docker CLI error") {
+	if !strings.Contains(body, "docker API error") {
 		t.Errorf("response should contain error message, got:\n%s", body)
 	}
 }
 
 func TestRootHandler_ZeroContainers(t *testing.T) {
-	runner := &stubRunner{output: []byte("")}
+	api := &stubDockerAPI{}
 	cfg := config.Config{Port: 8080, ProjectName: "Docker-CD", DockerSocket: "/var/run/docker.sock"}
 
-	router := setupRouter(runner, cfg)
+	router := setupRouterWithAPI(cfg, api)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
@@ -97,7 +120,7 @@ func TestRootHandler_ZeroContainers(t *testing.T) {
 }
 
 func TestRootHandler_ShowsRepoInfo(t *testing.T) {
-	runner := &stubRunner{output: []byte("a\n")}
+	api := &stubDockerAPI{containers: []types.Container{{ID: "a"}}}
 	cfg := config.Config{
 		Port:           8080,
 		ProjectName:    "Docker-CD",
@@ -108,7 +131,7 @@ func TestRootHandler_ShowsRepoInfo(t *testing.T) {
 		GitDeployDir:   "deployments/host-a",
 	}
 
-	router := setupRouter(runner, cfg)
+	router := setupRouterWithAPI(cfg, api)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
@@ -141,19 +164,18 @@ func signPayload(secret, payload string) string {
 	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
 }
 
-func setupRouterWithRefresh(runner handler.CommandRunner, cfg config.Config) *gin.Engine {
+func setupRouterWithRefresh(cfg config.Config) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	store := desiredstate.NewStore()
 	queue := refresh.NewQueue()
 	svc := refresh.NewService(cfg, store, queue, nil)
-	return handler.NewRouter(runner, cfg, svc, store, nil, nil, nil)
+	return handler.NewRouter(cfg, svc, store, nil, nil, nil, nil)
 }
 
 func TestWebhookHandler_NoSecretConfigured(t *testing.T) {
-	runner := &stubRunner{output: []byte("a\n")}
 	cfg := config.Config{Port: 8080, ProjectName: "Docker-CD", DockerSocket: "/var/run/docker.sock"}
 
-	router := setupRouterWithRefresh(runner, cfg)
+	router := setupRouterWithRefresh(cfg)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/webhook", strings.NewReader(`{"ref":"refs/heads/main"}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -170,7 +192,6 @@ func TestWebhookHandler_NoSecretConfigured(t *testing.T) {
 }
 
 func TestWebhookHandler_ValidSignature(t *testing.T) {
-	runner := &stubRunner{output: []byte("a\n")}
 	secret := "test-secret-123"
 	cfg := config.Config{
 		Port:          8080,
@@ -179,7 +200,7 @@ func TestWebhookHandler_ValidSignature(t *testing.T) {
 		WebhookSecret: secret,
 	}
 
-	router := setupRouterWithRefresh(runner, cfg)
+	router := setupRouterWithRefresh(cfg)
 
 	payload := `{"ref":"refs/heads/main"}`
 	sig := signPayload(secret, payload)
@@ -200,7 +221,6 @@ func TestWebhookHandler_ValidSignature(t *testing.T) {
 }
 
 func TestWebhookHandler_InvalidSignature(t *testing.T) {
-	runner := &stubRunner{output: []byte("a\n")}
 	cfg := config.Config{
 		Port:          8080,
 		ProjectName:   "Docker-CD",
@@ -208,7 +228,7 @@ func TestWebhookHandler_InvalidSignature(t *testing.T) {
 		WebhookSecret: "real-secret",
 	}
 
-	router := setupRouterWithRefresh(runner, cfg)
+	router := setupRouterWithRefresh(cfg)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/webhook", strings.NewReader(`{"ref":"refs/heads/main"}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -226,7 +246,6 @@ func TestWebhookHandler_InvalidSignature(t *testing.T) {
 }
 
 func TestWebhookHandler_MissingSignatureWhenRequired(t *testing.T) {
-	runner := &stubRunner{output: []byte("a\n")}
 	cfg := config.Config{
 		Port:          8080,
 		ProjectName:   "Docker-CD",
@@ -234,7 +253,7 @@ func TestWebhookHandler_MissingSignatureWhenRequired(t *testing.T) {
 		WebhookSecret: "needs-sig",
 	}
 
-	router := setupRouterWithRefresh(runner, cfg)
+	router := setupRouterWithRefresh(cfg)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/webhook", strings.NewReader(`{"ref":"refs/heads/main"}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -249,10 +268,9 @@ func TestWebhookHandler_MissingSignatureWhenRequired(t *testing.T) {
 // --- Manual refresh handler tests (T017) ---
 
 func TestManualRefreshHandler_ReturnsStatus(t *testing.T) {
-	runner := &stubRunner{output: []byte("a\n")}
 	cfg := config.Config{Port: 8080, ProjectName: "Docker-CD", DockerSocket: "/var/run/docker.sock"}
 
-	router := setupRouterWithRefresh(runner, cfg)
+	router := setupRouterWithRefresh(cfg)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/refresh", nil)
 	w := httptest.NewRecorder()
@@ -270,7 +288,6 @@ func TestManualRefreshHandler_ReturnsStatus(t *testing.T) {
 // --- Refresh status handler tests (T017) ---
 
 func TestRefreshStatusHandler_ReturnsJSON(t *testing.T) {
-	runner := &stubRunner{output: []byte("a\n")}
 	cfg := config.Config{Port: 8080, ProjectName: "Docker-CD", DockerSocket: "/var/run/docker.sock"}
 
 	store := desiredstate.NewStore()
@@ -278,7 +295,7 @@ func TestRefreshStatusHandler_ReturnsJSON(t *testing.T) {
 	svc := refresh.NewService(cfg, store, queue, nil)
 
 	gin.SetMode(gin.TestMode)
-	router := handler.NewRouter(runner, cfg, svc, store, nil, nil, nil)
+	router := handler.NewRouter(cfg, svc, store, nil, nil, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/refresh-status", nil)
 	w := httptest.NewRecorder()
@@ -294,7 +311,6 @@ func TestRefreshStatusHandler_ReturnsJSON(t *testing.T) {
 }
 
 func TestRefreshStatusHandler_WithPopulatedStore(t *testing.T) {
-	runner := &stubRunner{output: []byte("a\n")}
 	cfg := config.Config{Port: 8080, ProjectName: "Docker-CD", DockerSocket: "/var/run/docker.sock"}
 
 	store := desiredstate.NewStore()
@@ -311,7 +327,7 @@ func TestRefreshStatusHandler_WithPopulatedStore(t *testing.T) {
 	svc := refresh.NewService(cfg, store, queue, nil)
 
 	gin.SetMode(gin.TestMode)
-	router := handler.NewRouter(runner, cfg, svc, store, nil, nil, nil)
+	router := handler.NewRouter(cfg, svc, store, nil, nil, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/refresh-status", nil)
 	w := httptest.NewRecorder()
@@ -333,7 +349,6 @@ func TestRefreshStatusHandler_WithPopulatedStore(t *testing.T) {
 // --- Stacks handler tests (T017) ---
 
 func TestStacksHandler_EmptyStore(t *testing.T) {
-	runner := &stubRunner{output: []byte("a\n")}
 	cfg := config.Config{Port: 8080, ProjectName: "Docker-CD", DockerSocket: "/var/run/docker.sock"}
 
 	store := desiredstate.NewStore()
@@ -341,7 +356,7 @@ func TestStacksHandler_EmptyStore(t *testing.T) {
 	svc := refresh.NewService(cfg, store, queue, nil)
 
 	gin.SetMode(gin.TestMode)
-	router := handler.NewRouter(runner, cfg, svc, store, nil, nil, nil)
+	router := handler.NewRouter(cfg, svc, store, nil, nil, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/stacks", nil)
 	w := httptest.NewRecorder()
@@ -357,7 +372,6 @@ func TestStacksHandler_EmptyStore(t *testing.T) {
 }
 
 func TestStacksHandler_WithStacks(t *testing.T) {
-	runner := &stubRunner{output: []byte("a\n")}
 	cfg := config.Config{Port: 8080, ProjectName: "Docker-CD", DockerSocket: "/var/run/docker.sock"}
 
 	store := desiredstate.NewStore()
@@ -373,7 +387,7 @@ func TestStacksHandler_WithStacks(t *testing.T) {
 	svc := refresh.NewService(cfg, store, queue, nil)
 
 	gin.SetMode(gin.TestMode)
-	router := handler.NewRouter(runner, cfg, svc, store, nil, nil, nil)
+	router := handler.NewRouter(cfg, svc, store, nil, nil, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/stacks", nil)
 	w := httptest.NewRecorder()
@@ -397,7 +411,6 @@ func TestStacksHandler_WithStacks(t *testing.T) {
 // --- T018/T019: Sync metadata in API tests ---
 
 func TestStacksHandler_ExposeSyncMetadata(t *testing.T) {
-	runner := &stubRunner{output: []byte("a\n")}
 	cfg := config.Config{Port: 8080, ProjectName: "Docker-CD", DockerSocket: "/var/run/docker.sock"}
 
 	store := desiredstate.NewStore()
@@ -423,7 +436,7 @@ func TestStacksHandler_ExposeSyncMetadata(t *testing.T) {
 	svc := refresh.NewService(cfg, store, queue, nil)
 
 	gin.SetMode(gin.TestMode)
-	router := handler.NewRouter(runner, cfg, svc, store, nil, nil, nil)
+	router := handler.NewRouter(cfg, svc, store, nil, nil, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/stacks", nil)
 	w := httptest.NewRecorder()
@@ -456,7 +469,6 @@ func TestStacksHandler_ExposeSyncMetadata(t *testing.T) {
 }
 
 func TestStacksHandler_SyncErrorExposed(t *testing.T) {
-	runner := &stubRunner{output: []byte("a\n")}
 	cfg := config.Config{Port: 8080, ProjectName: "Docker-CD", DockerSocket: "/var/run/docker.sock"}
 
 	store := desiredstate.NewStore()
@@ -479,7 +491,7 @@ func TestStacksHandler_SyncErrorExposed(t *testing.T) {
 	svc := refresh.NewService(cfg, store, queue, nil)
 
 	gin.SetMode(gin.TestMode)
-	router := handler.NewRouter(runner, cfg, svc, store, nil, nil, nil)
+	router := handler.NewRouter(cfg, svc, store, nil, nil, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/stacks", nil)
 	w := httptest.NewRecorder()
@@ -509,7 +521,6 @@ func (s *stubReconciler) Reconcile(_ context.Context) []reconcile.Reconciliation
 }
 
 func TestAckHandler_Success(t *testing.T) {
-	runner := &stubRunner{output: []byte("a\n")}
 	cfg := config.Config{Port: 8080, ProjectName: "Docker-CD", DockerSocket: "/var/run/docker.sock"}
 
 	store := desiredstate.NewStore()
@@ -522,7 +533,7 @@ func TestAckHandler_Success(t *testing.T) {
 	}}
 
 	gin.SetMode(gin.TestMode)
-	router := handler.NewRouter(runner, cfg, svc, store, ackStore, rec, nil)
+	router := handler.NewRouter(cfg, svc, store, ackStore, rec, nil, nil)
 
 	body := `{"stack_path": "app1"}`
 	req := httptest.NewRequest(http.MethodPost, "/api/reconcile/ack", strings.NewReader(body))
@@ -543,7 +554,6 @@ func TestAckHandler_Success(t *testing.T) {
 }
 
 func TestAckHandler_MissingStackPath(t *testing.T) {
-	runner := &stubRunner{output: []byte("a\n")}
 	cfg := config.Config{Port: 8080, ProjectName: "Docker-CD", DockerSocket: "/var/run/docker.sock"}
 
 	store := desiredstate.NewStore()
@@ -554,7 +564,7 @@ func TestAckHandler_MissingStackPath(t *testing.T) {
 	rec := &stubReconciler{}
 
 	gin.SetMode(gin.TestMode)
-	router := handler.NewRouter(runner, cfg, svc, store, ackStore, rec, nil)
+	router := handler.NewRouter(cfg, svc, store, ackStore, rec, nil, nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/reconcile/ack", strings.NewReader(`{}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -583,7 +593,6 @@ func (s *stubScheduler) GetUpdateStatus() interface{} {
 }
 
 func TestTriggerUpdateHandler_Success(t *testing.T) {
-	runner := &stubRunner{output: []byte("a\n")}
 	cfg := config.Config{Port: 8080, ProjectName: "Docker-CD", DockerSocket: "/var/run/docker.sock"}
 
 	store := desiredstate.NewStore()
@@ -592,7 +601,7 @@ func TestTriggerUpdateHandler_Success(t *testing.T) {
 	scheduler := &stubScheduler{}
 
 	gin.SetMode(gin.TestMode)
-	router := handler.NewRouter(runner, cfg, svc, store, nil, nil, scheduler)
+	router := handler.NewRouter(cfg, svc, store, nil, nil, scheduler, nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/update", nil)
 	w := httptest.NewRecorder()
@@ -613,7 +622,6 @@ func TestTriggerUpdateHandler_Success(t *testing.T) {
 }
 
 func TestTriggerUpdateHandler_AlreadyRunning(t *testing.T) {
-	runner := &stubRunner{output: []byte("a\n")}
 	cfg := config.Config{Port: 8080, ProjectName: "Docker-CD", DockerSocket: "/var/run/docker.sock"}
 
 	store := desiredstate.NewStore()
@@ -624,7 +632,7 @@ func TestTriggerUpdateHandler_AlreadyRunning(t *testing.T) {
 	}
 
 	gin.SetMode(gin.TestMode)
-	router := handler.NewRouter(runner, cfg, svc, store, nil, nil, scheduler)
+	router := handler.NewRouter(cfg, svc, store, nil, nil, scheduler, nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/update", nil)
 	w := httptest.NewRecorder()
@@ -641,7 +649,6 @@ func TestTriggerUpdateHandler_AlreadyRunning(t *testing.T) {
 }
 
 func TestUpdateStatusHandler_NoUpdate(t *testing.T) {
-	runner := &stubRunner{output: []byte("a\n")}
 	cfg := config.Config{Port: 8080, ProjectName: "Docker-CD", DockerSocket: "/var/run/docker.sock"}
 
 	store := desiredstate.NewStore()
@@ -650,7 +657,7 @@ func TestUpdateStatusHandler_NoUpdate(t *testing.T) {
 	scheduler := &stubScheduler{status: nil} // No active update
 
 	gin.SetMode(gin.TestMode)
-	router := handler.NewRouter(runner, cfg, svc, store, nil, nil, scheduler)
+	router := handler.NewRouter(cfg, svc, store, nil, nil, scheduler, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/update/status", nil)
 	w := httptest.NewRecorder()
@@ -667,7 +674,6 @@ func TestUpdateStatusHandler_NoUpdate(t *testing.T) {
 }
 
 func TestUpdateStatusHandler_UpdateInProgress(t *testing.T) {
-	runner := &stubRunner{output: []byte("a\n")}
 	cfg := config.Config{Port: 8080, ProjectName: "Docker-CD", DockerSocket: "/var/run/docker.sock"}
 
 	store := desiredstate.NewStore()
@@ -678,7 +684,7 @@ func TestUpdateStatusHandler_UpdateInProgress(t *testing.T) {
 	}
 
 	gin.SetMode(gin.TestMode)
-	router := handler.NewRouter(runner, cfg, svc, store, nil, nil, scheduler)
+	router := handler.NewRouter(cfg, svc, store, nil, nil, scheduler, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/update/status", nil)
 	w := httptest.NewRecorder()

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -16,11 +16,11 @@ type ReconcileRunner interface {
 }
 
 // NewRouter creates a Gin engine with all routes registered.
-func NewRouter(runner CommandRunner, cfg config.Config, refreshSvc *refresh.Service, store *desiredstate.Store, ackStore *reconcile.AckStore, reconciler ReconcileRunner, scheduler UpdateTrigger, broadcaster ...*desiredstate.Broadcaster) *gin.Engine {
+func NewRouter(cfg config.Config, refreshSvc *refresh.Service, store *desiredstate.Store, ackStore *reconcile.AckStore, reconciler ReconcileRunner, scheduler UpdateTrigger, api DockerAPI, broadcaster ...*desiredstate.Broadcaster) *gin.Engine {
 	r := gin.New()
 	r.Use(gin.Recovery())
 
-	r.GET("/", RootHandler(runner, cfg))
+	r.GET("/", RootHandler(cfg, api))
 
 	// API routes
 	if refreshSvc != nil {

--- a/backend/internal/reconcile/compose.go
+++ b/backend/internal/reconcile/compose.go
@@ -270,6 +270,89 @@ func extractServiceNames(content []byte) []string {
 	return names
 }
 
+// ExtractComposeImages parses raw compose YAML content and returns the list
+// of image references. Uses the same lightweight line-parsing approach as
+// extractServiceNames. Services with build: but no image: are skipped.
+// Duplicate images are deduplicated.
+func ExtractComposeImages(content []byte) []string {
+	lines := strings.Split(string(content), "\n")
+	inServices := false
+	serviceIndent := -1
+	propIndent := -1
+	var images []string
+	seen := make(map[string]bool)
+	currentImage := ""
+
+	flush := func() {
+		if currentImage != "" && !seen[currentImage] {
+			images = append(images, currentImage)
+			seen[currentImage] = true
+		}
+		currentImage = ""
+	}
+
+	for _, line := range lines {
+		trimmed := strings.TrimRight(line, " \t\r")
+		stripped := strings.TrimSpace(trimmed)
+
+		if stripped == "" || strings.HasPrefix(stripped, "#") {
+			continue
+		}
+
+		// Detect top-level "services:" key
+		if stripped == "services:" && countIndent(trimmed) == 0 {
+			inServices = true
+			continue
+		}
+
+		if !inServices {
+			continue
+		}
+
+		indent := countIndent(trimmed)
+
+		// Non-indented line means new top-level key — stop
+		if indent == 0 {
+			flush()
+			break
+		}
+
+		// Detect service indent level from first indented line
+		if serviceIndent < 0 {
+			serviceIndent = indent
+		}
+
+		// New service block
+		if indent == serviceIndent && strings.HasSuffix(stripped, ":") {
+			flush()
+			propIndent = -1
+			continue
+		}
+
+		// Detect property indent from first line under service
+		if propIndent < 0 && indent > serviceIndent {
+			propIndent = indent
+		}
+
+		// Only look at direct service properties
+		if propIndent > 0 && indent == propIndent {
+			if strings.HasPrefix(stripped, "image:") {
+				val := strings.TrimSpace(strings.TrimPrefix(stripped, "image:"))
+				// Remove quotes
+				val = strings.Trim(val, "\"'")
+				if val != "" {
+					currentImage = val
+				}
+			}
+		}
+	}
+
+	// Flush last service
+	flush()
+
+	return images
+}
+
 // countIndent returns the effective indentation width of a line,
 // treating tabs as 4 spaces.
 func countIndent(line string) int {

--- a/backend/internal/reconcile/compose_test.go
+++ b/backend/internal/reconcile/compose_test.go
@@ -1,0 +1,354 @@
+package reconcile
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/lucasreiners/docker-cd/internal/docker"
+)
+
+// argCapturingRunner records all calls to Run.
+type argCapturingRunner struct {
+	calls []runCall
+	out   []byte
+	err   error
+}
+
+type runCall struct {
+	Name string
+	Args []string
+}
+
+func (r *argCapturingRunner) Run(_ context.Context, name string, args ...string) ([]byte, error) {
+	r.calls = append(r.calls, runCall{Name: name, Args: args})
+	return r.out, r.err
+}
+
+// --- ComposeUp tests ---
+
+func TestComposeUp_BaseArgs(t *testing.T) {
+	runner := &argCapturingRunner{}
+	cr := NewDockerComposeRunner(runner, "/var/run/docker.sock")
+
+	err := cr.ComposeUp(context.Background(), "myproject", "/tmp/compose.yml", "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(runner.calls))
+	}
+
+	args := runner.calls[0].Args
+	expected := []string{"-H", "unix:///var/run/docker.sock", "compose", "-p", "myproject", "-f", "/tmp/compose.yml", "up", "-d"}
+	if !sliceEqual(args, expected) {
+		t.Errorf("args = %v, want %v", args, expected)
+	}
+}
+
+func TestComposeUp_WithWorkDir(t *testing.T) {
+	runner := &argCapturingRunner{}
+	cr := NewDockerComposeRunner(runner, "")
+
+	err := cr.ComposeUp(context.Background(), "proj", "/tmp/c.yml", "", "/work/dir")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	args := runner.calls[0].Args
+	if !containsSequence(args, "--project-directory", "/work/dir") {
+		t.Errorf("expected --project-directory /work/dir in args: %v", args)
+	}
+}
+
+func TestComposeUp_WithOverrideFile(t *testing.T) {
+	runner := &argCapturingRunner{}
+	cr := NewDockerComposeRunner(runner, "")
+
+	err := cr.ComposeUp(context.Background(), "proj", "/tmp/c.yml", "/tmp/override.yml", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	args := runner.calls[0].Args
+	// Should have two -f flags: compose file then override
+	fIndices := findAllIndices(args, "-f")
+	if len(fIndices) != 2 {
+		t.Fatalf("expected 2 -f flags, got %d in %v", len(fIndices), args)
+	}
+	if args[fIndices[0]+1] != "/tmp/c.yml" {
+		t.Errorf("first -f value = %s, want /tmp/c.yml", args[fIndices[0]+1])
+	}
+	if args[fIndices[1]+1] != "/tmp/override.yml" {
+		t.Errorf("second -f value = %s, want /tmp/override.yml", args[fIndices[1]+1])
+	}
+}
+
+func TestComposeUp_NoOverrideFile(t *testing.T) {
+	runner := &argCapturingRunner{}
+	cr := NewDockerComposeRunner(runner, "")
+
+	_ = cr.ComposeUp(context.Background(), "proj", "/tmp/c.yml", "", "")
+
+	args := runner.calls[0].Args
+	fIndices := findAllIndices(args, "-f")
+	if len(fIndices) != 1 {
+		t.Errorf("expected 1 -f flag when no override, got %d in %v", len(fIndices), args)
+	}
+}
+
+func TestComposeUp_ErrorWrapping(t *testing.T) {
+	runner := &argCapturingRunner{out: []byte("some output"), err: errors.New("exit 1")}
+	cr := NewDockerComposeRunner(runner, "")
+
+	err := cr.ComposeUp(context.Background(), "proj", "/tmp/c.yml", "", "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "docker compose up failed") {
+		t.Errorf("error = %q, want to contain 'docker compose up failed'", err.Error())
+	}
+	if !strings.Contains(err.Error(), "some output") {
+		t.Errorf("error = %q, want to contain CLI output", err.Error())
+	}
+}
+
+func TestComposeUp_EmptySocket(t *testing.T) {
+	runner := &argCapturingRunner{}
+	cr := NewDockerComposeRunner(runner, "")
+
+	_ = cr.ComposeUp(context.Background(), "proj", "/tmp/c.yml", "", "")
+
+	args := runner.calls[0].Args
+	// No -H flag when socket is empty
+	for _, a := range args {
+		if a == "-H" {
+			t.Errorf("expected no -H flag with empty socket, got args: %v", args)
+			break
+		}
+	}
+}
+
+// --- ComposeDown tests ---
+
+func TestComposeDown_BaseArgs(t *testing.T) {
+	runner := &argCapturingRunner{}
+	cr := NewDockerComposeRunner(runner, "/var/run/docker.sock")
+
+	err := cr.ComposeDown(context.Background(), "myproject", "/tmp/compose.yml", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	args := runner.calls[0].Args
+	expected := []string{"-H", "unix:///var/run/docker.sock", "compose", "-p", "myproject", "-f", "/tmp/compose.yml", "down", "--remove-orphans"}
+	if !sliceEqual(args, expected) {
+		t.Errorf("args = %v, want %v", args, expected)
+	}
+}
+
+func TestComposeDown_WithWorkDir(t *testing.T) {
+	runner := &argCapturingRunner{}
+	cr := NewDockerComposeRunner(runner, "")
+
+	_ = cr.ComposeDown(context.Background(), "proj", "/tmp/c.yml", "/work")
+
+	args := runner.calls[0].Args
+	if !containsSequence(args, "--project-directory", "/work") {
+		t.Errorf("expected --project-directory /work in args: %v", args)
+	}
+}
+
+func TestComposeDown_EmptyComposeFile(t *testing.T) {
+	runner := &argCapturingRunner{}
+	cr := NewDockerComposeRunner(runner, "")
+
+	_ = cr.ComposeDown(context.Background(), "proj", "", "")
+
+	args := runner.calls[0].Args
+	for _, a := range args {
+		if a == "-f" {
+			t.Errorf("expected no -f flag with empty compose file, got args: %v", args)
+			break
+		}
+	}
+}
+
+func TestComposeDown_ErrorWrapping(t *testing.T) {
+	runner := &argCapturingRunner{out: []byte("error output"), err: errors.New("exit 1")}
+	cr := NewDockerComposeRunner(runner, "")
+
+	err := cr.ComposeDown(context.Background(), "proj", "/tmp/c.yml", "")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "docker compose down failed") {
+		t.Errorf("error = %q, want to contain 'docker compose down failed'", err.Error())
+	}
+}
+
+// --- ComposePs tests ---
+
+func TestComposePs_SingleContainer(t *testing.T) {
+	jsonLine := `{"ID":"abcdef1234567890","Name":"web-1","Service":"web","State":"running","Health":"healthy","Image":"nginx:latest","Publishers":[{"URL":"","TargetPort":80,"PublishedPort":8080,"Protocol":"tcp"}]}`
+	runner := &argCapturingRunner{out: []byte(jsonLine)}
+	cr := NewDockerComposeRunner(runner, "")
+
+	containers, err := cr.ComposePs(context.Background(), "proj")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(containers) != 1 {
+		t.Fatalf("expected 1 container, got %d", len(containers))
+	}
+	c := containers[0]
+	if c.ID != "abcdef123456" { // truncated to 12
+		t.Errorf("ID = %q, want %q", c.ID, "abcdef123456")
+	}
+	if c.Name != "web-1" {
+		t.Errorf("Name = %q, want %q", c.Name, "web-1")
+	}
+	if c.Service != "web" {
+		t.Errorf("Service = %q, want %q", c.Service, "web")
+	}
+	if c.State != "running" {
+		t.Errorf("State = %q, want %q", c.State, "running")
+	}
+	if c.Health != "healthy" {
+		t.Errorf("Health = %q, want %q", c.Health, "healthy")
+	}
+	if c.Ports != "8080:80/tcp" {
+		t.Errorf("Ports = %q, want %q", c.Ports, "8080:80/tcp")
+	}
+}
+
+func TestComposePs_MultipleContainers(t *testing.T) {
+	lines := `{"ID":"aaaaaaaaaaaa1234","Name":"web-1","Service":"web","State":"running","Health":"","Image":"nginx","Publishers":[]}
+{"ID":"bbbbbbbbbbbb5678","Name":"db-1","Service":"db","State":"exited","Health":"","Image":"postgres","Publishers":[]}`
+	runner := &argCapturingRunner{out: []byte(lines)}
+	cr := NewDockerComposeRunner(runner, "")
+
+	containers, err := cr.ComposePs(context.Background(), "proj")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(containers) != 2 {
+		t.Fatalf("expected 2 containers, got %d", len(containers))
+	}
+}
+
+func TestComposePs_EmptyOutput(t *testing.T) {
+	runner := &argCapturingRunner{out: []byte("")}
+	cr := NewDockerComposeRunner(runner, "")
+
+	containers, err := cr.ComposePs(context.Background(), "proj")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if containers != nil {
+		t.Errorf("expected nil, got %v", containers)
+	}
+}
+
+func TestComposePs_HealthDefaultsToNone(t *testing.T) {
+	jsonLine := `{"ID":"abcdef1234567890","Name":"web-1","Service":"web","State":"running","Health":"","Image":"nginx","Publishers":[]}`
+	runner := &argCapturingRunner{out: []byte(jsonLine)}
+	cr := NewDockerComposeRunner(runner, "")
+
+	containers, err := cr.ComposePs(context.Background(), "proj")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if containers[0].Health != "none" {
+		t.Errorf("Health = %q, want %q", containers[0].Health, "none")
+	}
+}
+
+func TestComposePs_UnpublishedPort(t *testing.T) {
+	jsonLine := `{"ID":"abcdef1234567890","Name":"web-1","Service":"web","State":"running","Health":"","Image":"nginx","Publishers":[{"URL":"","TargetPort":3000,"PublishedPort":0,"Protocol":"tcp"}]}`
+	runner := &argCapturingRunner{out: []byte(jsonLine)}
+	cr := NewDockerComposeRunner(runner, "")
+
+	containers, err := cr.ComposePs(context.Background(), "proj")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if containers[0].Ports != "3000/tcp" {
+		t.Errorf("Ports = %q, want %q", containers[0].Ports, "3000/tcp")
+	}
+}
+
+func TestComposePs_InvalidJSONSkipped(t *testing.T) {
+	lines := "not json\n" + `{"ID":"abcdef1234567890","Name":"web-1","Service":"web","State":"running","Health":"","Image":"nginx","Publishers":[]}`
+	runner := &argCapturingRunner{out: []byte(lines)}
+	cr := NewDockerComposeRunner(runner, "")
+
+	containers, err := cr.ComposePs(context.Background(), "proj")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(containers) != 1 {
+		t.Errorf("expected 1 container (invalid line skipped), got %d", len(containers))
+	}
+}
+
+func TestComposePs_RunnerError(t *testing.T) {
+	runner := &argCapturingRunner{err: errors.New("fail")}
+	cr := NewDockerComposeRunner(runner, "")
+
+	_, err := cr.ComposePs(context.Background(), "proj")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "docker compose ps failed") {
+		t.Errorf("error = %q, want to contain 'docker compose ps failed'", err.Error())
+	}
+}
+
+func TestComposePs_VerifiesArgs(t *testing.T) {
+	runner := &argCapturingRunner{out: []byte("")}
+	cr := NewDockerComposeRunner(runner, "/sock")
+
+	_, _ = cr.ComposePs(context.Background(), "myproj")
+
+	args := runner.calls[0].Args
+	hostArgs := docker.HostArgs("/sock")
+	expected := append(hostArgs, "compose", "-p", "myproj", "ps", "-a", "--format", "json")
+	if !sliceEqual(args, expected) {
+		t.Errorf("args = %v, want %v", args, expected)
+	}
+}
+
+// --- helpers ---
+
+func sliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func containsSequence(s []string, a, b string) bool {
+	for i := 0; i < len(s)-1; i++ {
+		if s[i] == a && s[i+1] == b {
+			return true
+		}
+	}
+	return false
+}
+
+func findAllIndices(s []string, val string) []int {
+	var indices []int
+	for i, v := range s {
+		if v == val {
+			indices = append(indices, i)
+		}
+	}
+	return indices
+}

--- a/backend/internal/reconcile/extract_test.go
+++ b/backend/internal/reconcile/extract_test.go
@@ -29,3 +29,85 @@ func TestExtractServiceNames_EdgeCases(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractComposeImages(t *testing.T) {
+	cases := []struct {
+		name string
+		content string
+		want []string
+	}{
+		{
+			"singleImage",
+			"services:\n  web:\n    image: nginx:alpine\n",
+			[]string{"nginx:alpine"},
+		},
+		{
+			"multipleServices",
+			"services:\n  web:\n    image: nginx:alpine\n  db:\n    image: postgres:16\n",
+			[]string{"nginx:alpine", "postgres:16"},
+		},
+		{
+			"buildOnly",
+			"services:\n  app:\n    build: .\n",
+			nil,
+		},
+		{
+			"buildAndImage",
+			"services:\n  app:\n    build: .\n    image: myapp:latest\n",
+			[]string{"myapp:latest"},
+		},
+		{
+			"deduplication",
+			"services:\n  web1:\n    image: nginx:alpine\n  web2:\n    image: nginx:alpine\n",
+			[]string{"nginx:alpine"},
+		},
+		{
+			"emptyContent",
+			"",
+			nil,
+		},
+		{
+			"quotedValue",
+			"services:\n  web:\n    image: \"nginx:alpine\"\n",
+			[]string{"nginx:alpine"},
+		},
+		{
+			"singleQuotedValue",
+			"services:\n  web:\n    image: 'nginx:alpine'\n",
+			[]string{"nginx:alpine"},
+		},
+		{
+			"withVersionAndVolumes",
+			"version: '3.8'\nservices:\n  web:\n    image: nginx:alpine\n  db:\n    image: postgres:16\nvolumes:\n  data:\n",
+			[]string{"nginx:alpine", "postgres:16"},
+		},
+		{
+			"4spaceIndent",
+			"services:\n    web:\n        image: nginx:alpine\n",
+			[]string{"nginx:alpine"},
+		},
+		{
+			"mixedBuildAndImage",
+			"services:\n  frontend:\n    build: ./frontend\n  backend:\n    image: node:20\n  db:\n    image: postgres:16\n",
+			[]string{"node:20", "postgres:16"},
+		},
+		{
+			"commentedImageLine",
+			"services:\n  web:\n    # image: old:tag\n    image: nginx:alpine\n",
+			[]string{"nginx:alpine"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ExtractComposeImages([]byte(tc.content))
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v (len %d), want %v (len %d)", got, len(got), tc.want, len(tc.want))
+			}
+			for i, img := range got {
+				if img != tc.want[i] {
+					t.Errorf("image[%d]: got %q, want %q", i, img, tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/backend/internal/reconcile/labels_test.go
+++ b/backend/internal/reconcile/labels_test.go
@@ -1,0 +1,165 @@
+package reconcile
+
+import (
+	"strings"
+	"testing"
+)
+
+// --- generateLabelArgs tests ---
+
+func TestGenerateLabelArgs_AllKeysPresent(t *testing.T) {
+	m := generateLabelArgs("stacks/app", "abc123", "initial commit", "hash456")
+
+	expectedKeys := []string{
+		LabelStackPath,
+		LabelDesiredRevision,
+		LabelDesiredCommitMessage,
+		LabelDesiredComposeHash,
+		LabelSyncedAt,
+		LabelSyncAt,
+		LabelSyncStatus,
+	}
+	if len(m) != len(expectedKeys) {
+		t.Fatalf("expected %d keys, got %d", len(expectedKeys), len(m))
+	}
+	for _, k := range expectedKeys {
+		if _, ok := m[k]; !ok {
+			t.Errorf("missing key %q", k)
+		}
+	}
+}
+
+func TestGenerateLabelArgs_ValuesMatch(t *testing.T) {
+	m := generateLabelArgs("stacks/app", "abc123", "my commit", "hash789")
+
+	if m[LabelStackPath] != "stacks/app" {
+		t.Errorf("stack path = %q, want %q", m[LabelStackPath], "stacks/app")
+	}
+	if m[LabelDesiredRevision] != "abc123" {
+		t.Errorf("revision = %q, want %q", m[LabelDesiredRevision], "abc123")
+	}
+	if m[LabelDesiredCommitMessage] != "my commit" {
+		t.Errorf("commit message = %q, want %q", m[LabelDesiredCommitMessage], "my commit")
+	}
+	if m[LabelDesiredComposeHash] != "hash789" {
+		t.Errorf("compose hash = %q, want %q", m[LabelDesiredComposeHash], "hash789")
+	}
+	if m[LabelSyncStatus] != "synced" {
+		t.Errorf("sync status = %q, want %q", m[LabelSyncStatus], "synced")
+	}
+}
+
+func TestGenerateLabelArgs_TimestampsNotEmpty(t *testing.T) {
+	m := generateLabelArgs("p", "r", "c", "h")
+	if m[LabelSyncedAt] == "" {
+		t.Error("LabelSyncedAt is empty")
+	}
+	if m[LabelSyncAt] == "" {
+		t.Error("LabelSyncAt is empty")
+	}
+}
+
+// --- generateLabelOverride tests ---
+
+func TestGenerateLabelOverride_EmptyServices(t *testing.T) {
+	result := generateLabelOverride("path", "rev", "msg", "hash", nil)
+	if result != "" {
+		t.Errorf("expected empty string for no services, got %q", result)
+	}
+}
+
+func TestGenerateLabelOverride_SingleService(t *testing.T) {
+	result := generateLabelOverride("stacks/app", "abc", "msg", "hash", []string{"web"})
+
+	if !strings.HasPrefix(result, "services:\n") {
+		t.Errorf("expected to start with 'services:\\n', got %q", result[:20])
+	}
+	if !strings.Contains(result, "  web:\n") {
+		t.Error("expected service 'web' in output")
+	}
+	if !strings.Contains(result, LabelStackPath) {
+		t.Error("expected LabelStackPath in output")
+	}
+	if !strings.Contains(result, LabelDesiredRevision) {
+		t.Error("expected LabelDesiredRevision in output")
+	}
+	if !strings.Contains(result, `"synced"`) {
+		t.Error("expected sync status 'synced' in output")
+	}
+}
+
+func TestGenerateLabelOverride_MultipleServices(t *testing.T) {
+	result := generateLabelOverride("p", "r", "m", "h", []string{"web", "db", "cache"})
+
+	for _, svc := range []string{"web", "db", "cache"} {
+		if !strings.Contains(result, "  "+svc+":\n") {
+			t.Errorf("expected service %q in output", svc)
+		}
+	}
+}
+
+func TestGenerateLabelOverride_EscapesQuotes(t *testing.T) {
+	result := generateLabelOverride("p", "r", `commit with "quotes"`, "h", []string{"web"})
+
+	if strings.Contains(result, `"quotes"`) && !strings.Contains(result, `\"quotes\"`) {
+		t.Error("expected double quotes to be escaped")
+	}
+}
+
+func TestGenerateLabelOverride_EscapesNewlines(t *testing.T) {
+	result := generateLabelOverride("p", "r", "line1\nline2", "h", []string{"web"})
+
+	if strings.Contains(result, "\nline2") {
+		// The newline in the commit message should be replaced with space
+		lines := strings.Split(result, "\n")
+		for _, l := range lines {
+			if strings.Contains(l, "line1") && strings.Contains(l, "line2") {
+				return // good — both on same line
+			}
+		}
+		t.Error("expected newline in commit message to be replaced with space")
+	}
+}
+
+// --- AllLabelKeys tests ---
+
+func TestAllLabelKeys_Count(t *testing.T) {
+	keys := AllLabelKeys()
+	if len(keys) != 8 {
+		t.Errorf("expected 8 keys, got %d: %v", len(keys), keys)
+	}
+}
+
+func TestAllLabelKeys_ContainsAll(t *testing.T) {
+	keys := AllLabelKeys()
+	expected := []string{
+		LabelStackPath,
+		LabelDesiredRevision,
+		LabelDesiredCommitMessage,
+		LabelDesiredComposeHash,
+		LabelSyncedAt,
+		LabelSyncAt,
+		LabelSyncStatus,
+		LabelSyncError,
+	}
+	keySet := make(map[string]bool)
+	for _, k := range keys {
+		keySet[k] = true
+	}
+	for _, e := range expected {
+		if !keySet[e] {
+			t.Errorf("missing key %q", e)
+		}
+	}
+}
+
+func TestAllLabelKeys_NoDuplicates(t *testing.T) {
+	keys := AllLabelKeys()
+	seen := make(map[string]bool)
+	for _, k := range keys {
+		if seen[k] {
+			t.Errorf("duplicate key %q", k)
+		}
+		seen[k] = true
+	}
+}

--- a/backend/internal/reconcile/reconcile_test.go
+++ b/backend/internal/reconcile/reconcile_test.go
@@ -879,3 +879,77 @@ func TestReconcile_NoOp_MultipleStacksInSync(t *testing.T) {
 		t.Errorf("expected 0 compose down calls, got %d", len(compose.downCalls))
 	}
 }
+
+// --- CancelActive tests ---
+
+// blockingComposeRunner blocks ComposeUp until the context is cancelled.
+type blockingComposeRunner struct {
+	upStarted chan struct{} // closed when ComposeUp begins
+}
+
+func (b *blockingComposeRunner) ComposeUp(ctx context.Context, _, _, _, _ string) error {
+	close(b.upStarted)
+	<-ctx.Done()
+	return ctx.Err()
+}
+func (b *blockingComposeRunner) ComposeDown(_ context.Context, _, _, _ string) error { return nil }
+func (b *blockingComposeRunner) ComposePs(_ context.Context, _ string) ([]desiredstate.ContainerInfo, error) {
+	return nil, nil
+}
+
+func TestCancelActive_CancelsRunningReconcile(t *testing.T) {
+	store := desiredstate.NewStore()
+	composeContent := []byte("services:\n  web:\n    image: nginx\n")
+	store.Set(&desiredstate.Snapshot{
+		Revision:      "rev1",
+		CommitMessage: "deploy",
+		RefreshStatus: desiredstate.RefreshStatusCompleted,
+		Stacks: []desiredstate.StackRecord{
+			{Path: "app1", ComposeFile: "docker-compose.yml", ComposeHash: "h1", Status: desiredstate.StackSyncMissing, Content: composeContent},
+		},
+	})
+
+	compose := &blockingComposeRunner{upStarted: make(chan struct{})}
+	inspector := &stubInspector{labels: map[string]reconcile.StackSyncMetadata{}}
+	sm := newTestStateManager(store, compose)
+	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), sm, slog.Default())
+
+	done := make(chan []reconcile.ReconciliationRun, 1)
+	go func() {
+		done <- r.Reconcile(context.Background())
+	}()
+
+	// Wait for ComposeUp to start
+	select {
+	case <-compose.upStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ComposeUp did not start in time")
+	}
+
+	// Cancel the active reconciliation
+	r.CancelActive()
+
+	// Reconcile should return with a failure
+	select {
+	case runs := <-done:
+		if len(runs) != 1 {
+			t.Fatalf("expected 1 run, got %d", len(runs))
+		}
+		if runs[0].Result != "failed" {
+			t.Errorf("expected failed result after cancel, got %q", runs[0].Result)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Reconcile did not return after CancelActive")
+	}
+}
+
+func TestCancelActive_SafeWhenNoReconcileActive(t *testing.T) {
+	store := desiredstate.NewStore()
+	compose := &stubComposeRunner{}
+	inspector := &stubInspector{labels: map[string]reconcile.StackSyncMetadata{}}
+	sm := newTestStateManager(store, compose)
+	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), sm, slog.Default())
+
+	// Should not panic
+	r.CancelActive()
+}

--- a/backend/internal/reconcile/state_manager_test.go
+++ b/backend/internal/reconcile/state_manager_test.go
@@ -1,0 +1,86 @@
+package reconcile_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/lucasreiners/docker-cd/internal/desiredstate"
+	"github.com/lucasreiners/docker-cd/internal/reconcile"
+)
+
+// psStubComposeRunner returns canned ComposePs results.
+type psStubComposeRunner struct {
+	containers []desiredstate.ContainerInfo
+	psErr      error
+}
+
+func (s *psStubComposeRunner) ComposeUp(_ context.Context, _, _, _, _ string) error { return nil }
+func (s *psStubComposeRunner) ComposeDown(_ context.Context, _, _, _ string) error  { return nil }
+func (s *psStubComposeRunner) ComposePs(_ context.Context, _ string) ([]desiredstate.ContainerInfo, error) {
+	return s.containers, s.psErr
+}
+
+func TestUpdateContainerCounts_HappyPath(t *testing.T) {
+	store := desiredstate.NewStore()
+	store.Set(&desiredstate.Snapshot{
+		RefreshStatus: desiredstate.RefreshStatusCompleted,
+		Stacks: []desiredstate.StackRecord{
+			{Path: "stacks/app", Status: desiredstate.StackSyncSynced},
+		},
+	})
+
+	compose := &psStubComposeRunner{
+		containers: []desiredstate.ContainerInfo{
+			{ID: "aaa", State: "running"},
+			{ID: "bbb", State: "running"},
+			{ID: "ccc", State: "exited"},
+		},
+	}
+	sm := reconcile.NewStateManager(store, compose, nil, slog.Default())
+
+	sm.UpdateContainerCounts(context.Background(), "stacks/app", "proj")
+
+	snap := store.Get()
+	if snap.Stacks[0].ContainersRunning != 2 {
+		t.Errorf("ContainersRunning = %d, want 2", snap.Stacks[0].ContainersRunning)
+	}
+	if snap.Stacks[0].ContainersTotal != 3 {
+		t.Errorf("ContainersTotal = %d, want 3", snap.Stacks[0].ContainersTotal)
+	}
+}
+
+func TestUpdateContainerCounts_PsError(t *testing.T) {
+	store := desiredstate.NewStore()
+	store.Set(&desiredstate.Snapshot{
+		RefreshStatus: desiredstate.RefreshStatusCompleted,
+		Stacks: []desiredstate.StackRecord{
+			{Path: "stacks/app", Status: desiredstate.StackSyncSynced, ContainersRunning: 5},
+		},
+	})
+
+	compose := &psStubComposeRunner{psErr: errors.New("ps failed")}
+	sm := reconcile.NewStateManager(store, compose, nil, slog.Default())
+
+	sm.UpdateContainerCounts(context.Background(), "stacks/app", "proj")
+
+	// Counts should remain unchanged on error
+	snap := store.Get()
+	if snap.Stacks[0].ContainersRunning != 5 {
+		t.Errorf("ContainersRunning = %d, want 5 (unchanged)", snap.Stacks[0].ContainersRunning)
+	}
+}
+
+func TestUpdateContainerCounts_NilSnapshot(t *testing.T) {
+	store := desiredstate.NewStore()
+	// No snapshot set — store.Get() returns nil
+
+	compose := &psStubComposeRunner{
+		containers: []desiredstate.ContainerInfo{{ID: "a", State: "running"}},
+	}
+	sm := reconcile.NewStateManager(store, compose, nil, slog.Default())
+
+	// Should not panic
+	sm.UpdateContainerCounts(context.Background(), "stacks/app", "proj")
+}

--- a/backend/internal/scheduler/scheduler.go
+++ b/backend/internal/scheduler/scheduler.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
@@ -352,7 +350,25 @@ func (s *SchedulerService) executeUpdateCycle(ctx context.Context, cycle *Update
 			})
 		}
 
-		result := s.updateStack(ctx, stack)
+		// Build per-image pull progress callback for SSE
+		var onPullProgress docker.PullProgressFn
+		if s.broadcaster != nil {
+			onPullProgress = func(p docker.PullProgress) {
+				s.broadcaster.PublishUpdateProgress(map[string]interface{}{
+					"type":      "image_pull_progress",
+					"cycle_id":  cycle.CycleID,
+					"stack":     stack.Path,
+					"image":     p.Image,
+					"status":    p.Status,
+					"progress":  p.Progress,
+					"current":   p.Current,
+					"total":     p.Total,
+					"timestamp": time.Now(),
+				})
+			}
+		}
+
+		result := s.updateStack(ctx, stack, onPullProgress)
 		cycle.StacksProcessed++
 
 		if !result.Success {
@@ -450,7 +466,7 @@ func (s *SchedulerService) CancelActiveUpdate() {
 }
 
 // updateStack updates a single stack (T014-T016)
-func (s *SchedulerService) updateStack(ctx context.Context, stack desiredstate.StackRecord) StackUpdateResult {
+func (s *SchedulerService) updateStack(ctx context.Context, stack desiredstate.StackRecord, onPullProgress docker.PullProgressFn) StackUpdateResult {
 	result := StackUpdateResult{
 		StackName:   stack.Path,
 		ProjectName: stack.Path, // Use path as project name
@@ -459,17 +475,11 @@ func (s *SchedulerService) updateStack(ctx context.Context, stack desiredstate.S
 
 	s.logger.Info("updating stack", "stack", stack.Path)
 
-	deployDir := strings.Trim(s.config.GitDeployDir, "/")
-	stackDir := filepath.Join(s.repoPath, deployDir, stack.Path)
-	composePath := filepath.Join(stackDir, stack.ComposeFile)
-
 	// Get list of images in compose file (T015)
-	images, err := s.dockerClient.GetComposeImages(ctx, result.ProjectName, composePath, stackDir)
-	if err != nil {
-		s.logger.Warn("failed to list compose images, will reconcile unconditionally",
-			"stack", stack.Path,
-			"error", err)
-		images = nil // proceed without digest comparison
+	images := reconcile.ExtractComposeImages(stack.Content)
+	if len(images) == 0 {
+		s.logger.Warn("no images found in compose content, will reconcile unconditionally",
+			"stack", stack.Path)
 	}
 
 	// Get image digests before pull (T015)
@@ -493,7 +503,7 @@ func (s *SchedulerService) updateStack(ctx context.Context, stack desiredstate.S
 	}
 
 	// Pull images (T014)
-	err = s.dockerClient.PullImages(ctx, result.ProjectName, composePath, stackDir)
+	err := s.dockerClient.PullImages(ctx, images, onPullProgress)
 	result.PullEndTime = time.Now()
 
 	if err != nil {

--- a/backend/internal/scheduler/scheduler_test.go
+++ b/backend/internal/scheduler/scheduler_test.go
@@ -953,3 +953,110 @@ func (s *sequentialInspectRunner) Run(ctx context.Context, name string, args ...
 	// Delegate everything else to inner runner
 	return s.inner.Run(ctx, name, args...)
 }
+
+// --- CancelActiveUpdate tests ---
+
+// blockingMockRunner blocks on pull commands until context is cancelled.
+type blockingMockRunner struct {
+	pullStarted chan struct{} // closed when pull begins
+	inner       *mockRunner  // delegates non-pull commands
+}
+
+func (b *blockingMockRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	if name == "docker" && containsArgs(args, "compose", "pull") {
+		select {
+		case <-b.pullStarted:
+		default:
+			close(b.pullStarted)
+		}
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	return b.inner.Run(ctx, name, args...)
+}
+
+func TestCancelActiveUpdate_CancelsRunningCycle(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	cfg := config.Config{
+		UpdaterEnabled: true,
+		UpdaterCron:    "0 3 * * *",
+	}
+
+	store := desiredstate.NewStore()
+	store.Set(&desiredstate.Snapshot{
+		RefreshStatus: desiredstate.RefreshStatusCompleted,
+		Stacks: []desiredstate.StackRecord{{
+			Path:        "test-stack",
+			ComposeFile: "docker-compose.yml",
+			Content:     []byte("services:\n  web:\n    image: nginx\n"),
+			Status:      desiredstate.StackSyncSynced,
+		}},
+	})
+
+	inner := &mockRunner{
+		composeImages: "nginx:latest\n",
+		imageDigests:  map[string]string{"nginx:latest": "sha256:aaa"},
+	}
+	runner := &blockingMockRunner{
+		pullStarted: make(chan struct{}),
+		inner:       inner,
+	}
+	dockerClient := docker.NewClient(runner, cfg.DockerSocket)
+
+	svc, err := NewSchedulerService(cfg, logger, store, dockerClient, newTestReconciler(store), nil)
+	if err != nil {
+		t.Fatalf("Failed to create scheduler: %v", err)
+	}
+
+	err = svc.TriggerUpdateCycle(context.Background())
+	if err != nil {
+		t.Fatalf("TriggerUpdateCycle failed: %v", err)
+	}
+
+	// Wait for pull to start
+	select {
+	case <-runner.pullStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("pull did not start in time")
+	}
+
+	// Cancel the active update
+	svc.CancelActiveUpdate()
+
+	// Wait for cycle to complete (activeUpdate cleared)
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("update cycle did not terminate after cancel")
+		default:
+		}
+		svc.mu.Lock()
+		active := svc.activeUpdate
+		svc.mu.Unlock()
+		if active == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestCancelActiveUpdate_SafeWhenNoCycleActive(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	cfg := config.Config{
+		UpdaterEnabled: true,
+		UpdaterCron:    "0 3 * * *",
+	}
+
+	store := desiredstate.NewStore()
+	runner := &mockRunner{}
+	dockerClient := docker.NewClient(runner, cfg.DockerSocket)
+
+	svc, err := NewSchedulerService(cfg, logger, store, dockerClient, newTestReconciler(store), nil)
+	if err != nil {
+		t.Fatalf("Failed to create scheduler: %v", err)
+	}
+
+	// Should not panic
+	svc.CancelActiveUpdate()
+}

--- a/backend/internal/scheduler/scheduler_test.go
+++ b/backend/internal/scheduler/scheduler_test.go
@@ -3,11 +3,17 @@ package scheduler
 import (
 	"context"
 	"errors"
+	"io"
 	"log/slog"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/image"
 	"github.com/lucasreiners/docker-cd/internal/config"
 	"github.com/lucasreiners/docker-cd/internal/desiredstate"
 	"github.com/lucasreiners/docker-cd/internal/docker"
@@ -22,8 +28,7 @@ func TestNewSchedulerService_Disabled(t *testing.T) {
 	}
 
 	store := desiredstate.NewStore()
-	runner := &docker.ExecRunner{}
-	dockerClient := docker.NewClient(runner, cfg.DockerSocket)
+	dockerClient := docker.NewClient(nil)
 
 	svc, err := NewSchedulerService(cfg, logger, store, dockerClient, newTestReconciler(store), nil)
 	if err != nil {
@@ -57,8 +62,7 @@ func TestNewSchedulerService_ValidCron(t *testing.T) {
 			}
 
 			store := desiredstate.NewStore()
-			runner := &docker.ExecRunner{}
-			dockerClient := docker.NewClient(runner, cfg.DockerSocket)
+			dockerClient := docker.NewClient(nil)
 
 			svc, err := NewSchedulerService(cfg, logger, store, dockerClient, newTestReconciler(store), nil)
 			if err != nil {
@@ -98,8 +102,7 @@ func TestNewSchedulerService_InvalidCron(t *testing.T) {
 			}
 
 			store := desiredstate.NewStore()
-			runner := &docker.ExecRunner{}
-			dockerClient := docker.NewClient(runner, cfg.DockerSocket)
+			dockerClient := docker.NewClient(nil)
 
 			svc, err := NewSchedulerService(cfg, logger, store, dockerClient, newTestReconciler(store), nil)
 			if err != nil {
@@ -139,17 +142,11 @@ func TestNewSchedulerService_NilDependencies(t *testing.T) {
 // Mock CommandRunner for testing Docker client
 
 type mockRunner struct {
-	pullCalls     []pullCall
-	pruneCalls    int
-	pullError     error
-	pruneOut      string
-	pruneError    error
-	pullDelay     time.Duration     // Add delay to simulate slow operations
-	composeImages string            // output for "docker compose config --images"
-	imageDigests  map[string]string // image name -> digest for "docker inspect"
-	inspectCalls  []string          // track which images were inspected
-	configError   error             // error for "docker compose config --images"
-	inspectError  error             // error for "docker inspect"
+	pullDelay     time.Duration     // copied to mockDockerAPI
+	pullError     error             // copied to mockDockerAPI
+	imageDigests  map[string]string // image name -> digest (copied to mockDockerAPI)
+	inspectError  error             // error for inspect (copied to mockDockerAPI)
+	pruneError    error             // copied to mockDockerAPI
 }
 
 // Helper function to create a minimal reconciler for testing
@@ -180,80 +177,88 @@ func newTestReconciler(store *desiredstate.Store) *reconcile.Reconciler {
 	)
 }
 
-type pullCall struct {
-	name string
-	args []string
-}
-
 func (m *mockRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
-	// Check if it's a compose config --images command
-	if name == "docker" && containsArgs(args, "compose", "config", "--images") {
-		if m.configError != nil {
-			return nil, m.configError
-		}
-		out := m.composeImages
-		if out == "" {
-			out = "nginx:latest\n"
-		}
-		return []byte(out), nil
-	}
-
-	// Check if it's a compose pull command
-	if name == "docker" && containsArgs(args, "compose", "pull") {
-		if m.pullDelay > 0 {
-			time.Sleep(m.pullDelay)
-		}
-		m.pullCalls = append(m.pullCalls, pullCall{name: name, args: args})
-		return []byte{}, m.pullError
-	}
-
-	// Check if it's a docker inspect for image digest
-	if name == "docker" && containsArgs(args, "inspect") && containsArgs(args, "--format") {
-		// Extract image name (last argument)
-		imageName := args[len(args)-1]
-		m.inspectCalls = append(m.inspectCalls, imageName)
-		if m.inspectError != nil {
-			return nil, m.inspectError
-		}
-		if m.imageDigests != nil {
-			if digest, ok := m.imageDigests[imageName]; ok {
-				return []byte(digest + "\n"), nil
-			}
-		}
-		// Default digest
-		return []byte("sha256:default000\n"), nil
-	}
-
-	// Check if it's an image prune command
-	if name == "docker" && containsArgs(args, "image", "prune") {
-		m.pruneCalls++
-		if m.pruneError != nil {
-			return nil, m.pruneError
-		}
-		// Return realistic docker prune output
-		if m.pruneOut == "" {
-			m.pruneOut = "Total reclaimed space: 100MB\n"
-		}
-		return []byte(m.pruneOut), nil
-	}
-
 	return []byte{}, nil
 }
 
-func containsArgs(args []string, required ...string) bool {
-	for _, want := range required {
-		found := false
-		for _, arg := range args {
-			if arg == want {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return false
+// mockDockerAPI implements docker.DockerAPI for scheduler tests.
+type mockDockerAPI struct {
+	imageDigests map[string]string // image name -> digest
+	inspectCalls []string
+	inspectError error
+	pruneCalls   int
+	pruneError   error
+	pullError    error
+	pullDelay    time.Duration
+	pullCalls    int
+}
+
+func (m *mockDockerAPI) ContainerList(_ context.Context, _ container.ListOptions) ([]types.Container, error) {
+	return nil, nil
+}
+func (m *mockDockerAPI) ContainerInspect(_ context.Context, _ string) (types.ContainerJSON, error) {
+	return types.ContainerJSON{}, nil
+}
+func (m *mockDockerAPI) ImageInspectWithRaw(_ context.Context, imageID string) (types.ImageInspect, []byte, error) {
+	m.inspectCalls = append(m.inspectCalls, imageID)
+	if m.inspectError != nil {
+		return types.ImageInspect{}, nil, m.inspectError
+	}
+	if m.imageDigests != nil {
+		if digest, ok := m.imageDigests[imageID]; ok {
+			return types.ImageInspect{ID: digest}, nil, nil
 		}
 	}
-	return true
+	return types.ImageInspect{ID: "sha256:default000"}, nil, nil
+}
+func (m *mockDockerAPI) ImagePull(ctx context.Context, _ string, _ image.PullOptions) (io.ReadCloser, error) {
+	m.pullCalls++
+	if m.pullDelay > 0 {
+		select {
+		case <-time.After(m.pullDelay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if m.pullError != nil {
+		return nil, m.pullError
+	}
+	stream := `{"status":"Pull complete"}` + "\n"
+	return io.NopCloser(strings.NewReader(stream)), nil
+}
+func (m *mockDockerAPI) ImagesPrune(_ context.Context, _ filters.Args) (image.PruneReport, error) {
+	m.pruneCalls++
+	if m.pruneError != nil {
+		return image.PruneReport{}, m.pruneError
+	}
+	return image.PruneReport{SpaceReclaimed: 100000000}, nil // 100MB
+}
+
+// newMockAPIFromRunner creates a mockDockerAPI that mirrors a mockRunner's config.
+func newMockAPIFromRunner(mr *mockRunner) *mockDockerAPI {
+	return &mockDockerAPI{
+		imageDigests: mr.imageDigests,
+		inspectError: mr.inspectError,
+		pruneError:   mr.pruneError,
+		pullError:    mr.pullError,
+		pullDelay:    mr.pullDelay,
+	}
+}
+
+// sequentialMockAPI returns sequential digests from ImageInspectWithRaw.
+type sequentialMockAPI struct {
+	mockDockerAPI
+	inspectDigests []string
+	inspectIndex   *int
+}
+
+func (s *sequentialMockAPI) ImageInspectWithRaw(_ context.Context, imageID string) (types.ImageInspect, []byte, error) {
+	idx := *s.inspectIndex
+	*s.inspectIndex++
+	if idx < len(s.inspectDigests) {
+		return types.ImageInspect{ID: s.inspectDigests[idx]}, nil, nil
+	}
+	return types.ImageInspect{ID: "sha256:fallback"}, nil, nil
 }
 
 // TestTriggerUpdateCycle_Success verifies manual trigger starts update cycle and completes
@@ -277,9 +282,10 @@ func TestTriggerUpdateCycle_Success(t *testing.T) {
 	})
 
 	mockRun := &mockRunner{
-		pruneOut: "Total reclaimed space: 100MB\n",
+		
 	}
-	dockerClient := docker.NewClient(mockRun, cfg.DockerSocket)
+	api := newMockAPIFromRunner(mockRun)
+	dockerClient := docker.NewClient(api)
 	broadcaster := desiredstate.NewBroadcaster()
 
 	svc, err := NewSchedulerService(cfg, logger, store, dockerClient, newTestReconciler(store), broadcaster)
@@ -303,11 +309,11 @@ func TestTriggerUpdateCycle_Success(t *testing.T) {
 	}
 
 	// Verify Docker client was called
-	if len(mockRun.pullCalls) != 1 {
-		t.Errorf("Expected 1 pull call, got %d", len(mockRun.pullCalls))
+	if api.pullCalls != 1 {
+		t.Errorf("Expected 1 pull call, got %d", api.pullCalls)
 	}
-	if mockRun.pruneCalls != 1 {
-		t.Errorf("Expected 1 prune call, got %d", mockRun.pruneCalls)
+	if api.pruneCalls != 1 {
+		t.Errorf("Expected 1 prune call, got %d", api.pruneCalls)
 	}
 
 	// Events were published via broadcaster (can't easily verify in unit test without subscriber)
@@ -335,9 +341,8 @@ func TestTriggerUpdateCycle_AlreadyRunning(t *testing.T) {
 	// Simulate slow pull operation with delay
 	mockRun := &mockRunner{
 		pullDelay: 500 * time.Millisecond, // Add delay to keep update running
-		pruneOut:  "Total reclaimed space: 100MB\\n",
 	}
-	dockerClient := docker.NewClient(mockRun, cfg.DockerSocket)
+	dockerClient := docker.NewClient(newMockAPIFromRunner(mockRun))
 
 	svc, err := NewSchedulerService(cfg, logger, store, dockerClient, newTestReconciler(store), nil)
 	if err != nil {
@@ -385,7 +390,7 @@ func TestGetUpdateStatus(t *testing.T) {
 
 	store := desiredstate.NewStore()
 	mockRun := &mockRunner{}
-	dockerClient := docker.NewClient(mockRun, cfg.DockerSocket)
+	dockerClient := docker.NewClient(newMockAPIFromRunner(mockRun))
 
 	svc, err := NewSchedulerService(cfg, logger, store, dockerClient, newTestReconciler(store), nil)
 	if err != nil {
@@ -431,7 +436,7 @@ func TestExecuteUpdateCycle_EmptyStore(t *testing.T) {
 	// Store is empty (nil snapshot)
 
 	mockRun := &mockRunner{}
-	dockerClient := docker.NewClient(mockRun, cfg.DockerSocket)
+	dockerClient := docker.NewClient(newMockAPIFromRunner(mockRun))
 
 	svc, err := NewSchedulerService(cfg, logger, store, dockerClient, newTestReconciler(store), nil)
 	if err != nil {
@@ -476,7 +481,8 @@ func TestExecuteUpdateCycle_SkipFailedStacks(t *testing.T) {
 	})
 
 	mockRun := &mockRunner{}
-	dockerClient := docker.NewClient(mockRun, cfg.DockerSocket)
+	api := newMockAPIFromRunner(mockRun)
+	dockerClient := docker.NewClient(api)
 
 	svc, err := NewSchedulerService(cfg, logger, store, dockerClient, newTestReconciler(store), nil)
 	if err != nil {
@@ -487,8 +493,8 @@ func TestExecuteUpdateCycle_SkipFailedStacks(t *testing.T) {
 	svc.executeUpdateCycle(context.Background(), cycle)
 
 	// Should only process healthy-stack (failed-stack skipped)
-	if len(mockRun.pullCalls) != 1 {
-		t.Errorf("Expected 1 pull call (only healthy stack), got %d", len(mockRun.pullCalls))
+	if api.pullCalls != 1 {
+		t.Errorf("Expected 1 pull call (only healthy stack), got %d", api.pullCalls)
 	}
 
 	if cycle.StacksProcessed != 1 {
@@ -524,8 +530,9 @@ func TestExecuteUpdateCycle_ContinueOnError(t *testing.T) {
 
 	// First call fails, second succeeds - use errors slice
 	mockRun := &mockRunner{}
+	api := newMockAPIFromRunner(mockRun)
 
-	dockerClient := docker.NewClient(mockRun, cfg.DockerSocket)
+	dockerClient := docker.NewClient(api)
 
 	svc, err := NewSchedulerService(cfg, logger, store, dockerClient, newTestReconciler(store), nil)
 	if err != nil {
@@ -533,7 +540,7 @@ func TestExecuteUpdateCycle_ContinueOnError(t *testing.T) {
 	}
 
 	// Set pull error for only the first pull attempt
-	mockRun.pullError = errors.New("pull failed for stack1")
+	api.pullError = errors.New("pull failed for stack1")
 
 	cycle := NewUpdateCycle()
 
@@ -544,7 +551,7 @@ func TestExecuteUpdateCycle_ContinueOnError(t *testing.T) {
 		Content:     []byte("services:\n  web:\n    image: nginx\n"),
 		Status:      desiredstate.StackSyncSynced,
 	}
-	result1 := svc.updateStack(context.Background(), stack1)
+	result1 := svc.updateStack(context.Background(), stack1, nil)
 	if result1.Success {
 		t.Error("Expected stack1 to fail")
 	}
@@ -554,7 +561,7 @@ func TestExecuteUpdateCycle_ContinueOnError(t *testing.T) {
 	}
 
 	// Clear the error for the second stack
-	mockRun.pullError = nil
+	api.pullError = nil
 
 	// Manually run the second stack which will succeed
 	stack2 := desiredstate.StackRecord{
@@ -563,7 +570,7 @@ func TestExecuteUpdateCycle_ContinueOnError(t *testing.T) {
 		Content:     []byte("services:\n  web:\n    image: nginx\n"),
 		Status:      desiredstate.StackSyncSynced,
 	}
-	result2 := svc.updateStack(context.Background(), stack2)
+	result2 := svc.updateStack(context.Background(), stack2, nil)
 	if !result2.Success {
 		t.Errorf("Expected stack2 to succeed, got error: %v", result2.Error)
 	}
@@ -601,10 +608,8 @@ func TestExecuteUpdateCycle_EventBroadcasting(t *testing.T) {
 		}},
 	})
 
-	mockRun := &mockRunner{
-		pruneOut: "Total reclaimed space: 500MB\n",
-	}
-	dockerClient := docker.NewClient(mockRun, cfg.DockerSocket)
+	mockRun := &mockRunner{}
+	dockerClient := docker.NewClient(newMockAPIFromRunner(mockRun))
 	broadcaster := desiredstate.NewBroadcaster()
 
 	svc, err := NewSchedulerService(cfg, logger, store, dockerClient, newTestReconciler(store), broadcaster)
@@ -643,16 +648,12 @@ func TestUpdateStack_DigestComparison_ImageChanged(t *testing.T) {
 
 	// Simulate digest change: before pull returns old digest, after pull returns new.
 	callCount := 0
-	mockRun := &mockRunner{
-		composeImages: "nginx:latest\n",
-	}
-	wrapRunner := &sequentialInspectRunner{
-		inner:          mockRun,
+	seqAPI := &sequentialMockAPI{
 		inspectDigests: []string{"sha256:olddigest111", "sha256:newdigest222"},
 		inspectIndex:   &callCount,
 	}
 
-	dockerClient := docker.NewClient(wrapRunner, cfg.DockerSocket)
+	dockerClient := docker.NewClient(seqAPI)
 
 	svc, err := NewSchedulerService(cfg, logger, store, dockerClient, newTestReconciler(store), nil)
 	if err != nil {
@@ -666,7 +667,7 @@ func TestUpdateStack_DigestComparison_ImageChanged(t *testing.T) {
 		Status:      desiredstate.StackSyncSynced,
 	}
 
-	result := svc.updateStack(context.Background(), stack)
+	result := svc.updateStack(context.Background(), stack, nil)
 
 	if !result.Success {
 		t.Fatalf("Expected success, got error: %v", result.Error)
@@ -713,17 +714,13 @@ func TestUpdateStack_DigestComparison_NoChange(t *testing.T) {
 
 	// Same digest before and after pull — no change.
 	callCount := 0
-	mockRun := &mockRunner{
-		composeImages: "nginx:latest\n",
-	}
 	sameDigest := "sha256:unchanged999"
-	wrapRunner := &sequentialInspectRunner{
-		inner:          mockRun,
+	seqAPI := &sequentialMockAPI{
 		inspectDigests: []string{sameDigest, sameDigest},
 		inspectIndex:   &callCount,
 	}
 
-	dockerClient := docker.NewClient(wrapRunner, cfg.DockerSocket)
+	dockerClient := docker.NewClient(seqAPI)
 
 	svc, err := NewSchedulerService(cfg, logger, store, dockerClient, newTestReconciler(store), nil)
 	if err != nil {
@@ -737,7 +734,7 @@ func TestUpdateStack_DigestComparison_NoChange(t *testing.T) {
 		Status:      desiredstate.StackSyncSynced,
 	}
 
-	result := svc.updateStack(context.Background(), stack)
+	result := svc.updateStack(context.Background(), stack, nil)
 
 	if !result.Success {
 		t.Fatalf("Expected success, got error: %v", result.Error)
@@ -776,19 +773,15 @@ func TestUpdateStack_DigestComparison_MultipleImages(t *testing.T) {
 	// nginx changes, postgres stays the same.
 	// Inspect order: nginx(before), postgres(before), nginx(after), postgres(after)
 	callCount := 0
-	mockRun := &mockRunner{
-		composeImages: "nginx:latest\npostgres:16\n",
-	}
-	wrapRunner := &sequentialInspectRunner{
-		inner: mockRun,
+	seqAPI := &sequentialMockAPI{
 		inspectDigests: []string{
-			"sha256:nginx_old", "sha256:pg_same", // before pull
-			"sha256:nginx_new", "sha256:pg_same", // after pull
+			"sha256:nginx_old", "sha256:pg_same",
+			"sha256:nginx_new", "sha256:pg_same",
 		},
 		inspectIndex: &callCount,
 	}
 
-	dockerClient := docker.NewClient(wrapRunner, cfg.DockerSocket)
+	dockerClient := docker.NewClient(seqAPI)
 
 	svc, err := NewSchedulerService(cfg, logger, store, dockerClient, newTestReconciler(store), nil)
 	if err != nil {
@@ -802,7 +795,7 @@ func TestUpdateStack_DigestComparison_MultipleImages(t *testing.T) {
 		Status:      desiredstate.StackSyncSynced,
 	}
 
-	result := svc.updateStack(context.Background(), stack)
+	result := svc.updateStack(context.Background(), stack, nil)
 
 	if !result.Success {
 		t.Fatalf("Expected success, got error: %v", result.Error)
@@ -856,11 +849,11 @@ func TestUpdateStack_DigestComparison_InspectFailure(t *testing.T) {
 	})
 
 	mockRun := &mockRunner{
-		composeImages: "nginx:latest\n",
+		
 		inspectError:  errors.New("inspect failed"),
 	}
 
-	dockerClient := docker.NewClient(mockRun, cfg.DockerSocket)
+	dockerClient := docker.NewClient(newMockAPIFromRunner(mockRun))
 
 	svc, err := NewSchedulerService(cfg, logger, store, dockerClient, newTestReconciler(store), nil)
 	if err != nil {
@@ -874,7 +867,7 @@ func TestUpdateStack_DigestComparison_InspectFailure(t *testing.T) {
 		Status:      desiredstate.StackSyncSynced,
 	}
 
-	result := svc.updateStack(context.Background(), stack)
+	result := svc.updateStack(context.Background(), stack, nil)
 
 	// Should still succeed — inspect failure is non-fatal, just triggers reconcile as fallback
 	if !result.Success {
@@ -885,30 +878,28 @@ func TestUpdateStack_DigestComparison_InspectFailure(t *testing.T) {
 	}
 }
 
-// TestUpdateStack_ConfigImagesFailure verifies graceful handling
-// when getting compose images fails (should still pull and reconcile).
-func TestUpdateStack_ConfigImagesFailure(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+// TestUpdateStack_EmptyContentFallback verifies graceful handling
+// when stack content has no images (equivalent to old config --images failure).
+func TestUpdateStack_EmptyContentFallback(t *testing.T) {
 	cfg := config.Config{
 		UpdaterEnabled: true,
 		UpdaterCron:    "0 3 * * *",
 	}
 
+	logger := slog.Default()
 	store := desiredstate.NewStore()
 	store.Set(&desiredstate.Snapshot{
 		Stacks: []desiredstate.StackRecord{{
 			Path:        "test-stack",
 			ComposeFile: "docker-compose.yml",
-			Content:     []byte("services:\n  web:\n    image: nginx:latest\n"),
+			Content:     []byte(""),
 			Status:      desiredstate.StackSyncSynced,
 		}},
 	})
 
-	mockRun := &mockRunner{
-		configError: errors.New("config --images failed"),
-	}
+	mockRun := &mockRunner{}
 
-	dockerClient := docker.NewClient(mockRun, cfg.DockerSocket)
+	dockerClient := docker.NewClient(newMockAPIFromRunner(mockRun))
 
 	svc, err := NewSchedulerService(cfg, logger, store, dockerClient, newTestReconciler(store), nil)
 	if err != nil {
@@ -918,61 +909,37 @@ func TestUpdateStack_ConfigImagesFailure(t *testing.T) {
 	stack := desiredstate.StackRecord{
 		Path:        "test-stack",
 		ComposeFile: "docker-compose.yml",
-		Content:     []byte("services:\n  web:\n    image: nginx:latest\n"),
+		Content:     []byte(""),
 		Status:      desiredstate.StackSyncSynced,
 	}
 
-	result := svc.updateStack(context.Background(), stack)
+	result := svc.updateStack(context.Background(), stack, nil)
 
-	// Should still succeed — config failure is non-fatal, just triggers reconcile as fallback
+	// Should still succeed — empty content triggers unconditional reconcile
 	if !result.Success {
-		t.Fatalf("Expected success even with config failure, got error: %v", result.Error)
+		t.Fatalf("Expected success even with empty content, got error: %v", result.Error)
 	}
 	if !result.ReconcileTriggered {
-		t.Error("Expected reconciliation to be triggered as fallback when config --images fails")
+		t.Error("Expected reconciliation to be triggered as fallback when no images found")
 	}
-}
-
-// sequentialInspectRunner wraps a mockRunner but returns sequential digests for inspect calls.
-type sequentialInspectRunner struct {
-	inner          *mockRunner
-	inspectDigests []string
-	inspectIndex   *int
-}
-
-func (s *sequentialInspectRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
-	// Intercept docker inspect calls for digest lookups
-	if name == "docker" && containsArgs(args, "inspect") && containsArgs(args, "--format") {
-		idx := *s.inspectIndex
-		*s.inspectIndex++
-		if idx < len(s.inspectDigests) {
-			return []byte(s.inspectDigests[idx] + "\n"), nil
-		}
-		return []byte("sha256:fallback\n"), nil
-	}
-	// Delegate everything else to inner runner
-	return s.inner.Run(ctx, name, args...)
 }
 
 // --- CancelActiveUpdate tests ---
 
-// blockingMockRunner blocks on pull commands until context is cancelled.
-type blockingMockRunner struct {
+// blockingMockAPI blocks on ImagePull until context is cancelled.
+type blockingMockAPI struct {
+	mockDockerAPI
 	pullStarted chan struct{} // closed when pull begins
-	inner       *mockRunner  // delegates non-pull commands
 }
 
-func (b *blockingMockRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
-	if name == "docker" && containsArgs(args, "compose", "pull") {
-		select {
-		case <-b.pullStarted:
-		default:
-			close(b.pullStarted)
-		}
-		<-ctx.Done()
-		return nil, ctx.Err()
+func (b *blockingMockAPI) ImagePull(ctx context.Context, _ string, _ image.PullOptions) (io.ReadCloser, error) {
+	select {
+	case <-b.pullStarted:
+	default:
+		close(b.pullStarted)
 	}
-	return b.inner.Run(ctx, name, args...)
+	<-ctx.Done()
+	return nil, ctx.Err()
 }
 
 func TestCancelActiveUpdate_CancelsRunningCycle(t *testing.T) {
@@ -994,14 +961,15 @@ func TestCancelActiveUpdate_CancelsRunningCycle(t *testing.T) {
 	})
 
 	inner := &mockRunner{
-		composeImages: "nginx:latest\n",
-		imageDigests:  map[string]string{"nginx:latest": "sha256:aaa"},
+		imageDigests:  map[string]string{"nginx": "sha256:aaa"},
 	}
-	runner := &blockingMockRunner{
+	blockingAPI := &blockingMockAPI{
+		mockDockerAPI: mockDockerAPI{
+			imageDigests: inner.imageDigests,
+		},
 		pullStarted: make(chan struct{}),
-		inner:       inner,
 	}
-	dockerClient := docker.NewClient(runner, cfg.DockerSocket)
+	dockerClient := docker.NewClient(blockingAPI)
 
 	svc, err := NewSchedulerService(cfg, logger, store, dockerClient, newTestReconciler(store), nil)
 	if err != nil {
@@ -1015,7 +983,7 @@ func TestCancelActiveUpdate_CancelsRunningCycle(t *testing.T) {
 
 	// Wait for pull to start
 	select {
-	case <-runner.pullStarted:
+	case <-blockingAPI.pullStarted:
 	case <-time.After(2 * time.Second):
 		t.Fatal("pull did not start in time")
 	}
@@ -1049,8 +1017,7 @@ func TestCancelActiveUpdate_SafeWhenNoCycleActive(t *testing.T) {
 	}
 
 	store := desiredstate.NewStore()
-	runner := &mockRunner{}
-	dockerClient := docker.NewClient(runner, cfg.DockerSocket)
+	dockerClient := docker.NewClient(nil)
 
 	svc, err := NewSchedulerService(cfg, logger, store, dockerClient, newTestReconciler(store), nil)
 	if err != nil {

--- a/backend/tests/integration/dind_compose_test.go
+++ b/backend/tests/integration/dind_compose_test.go
@@ -39,7 +39,7 @@ func TestDinD_ComposeUp_WritesFilesAndApplies(t *testing.T) {
 		t.Errorf("compose path should be absolute, got %q", composeFile)
 	}
 
-	err = composeRunner.ComposeUp(context.Background(), "mystack", composeFile, overrideFile, filepath.Dir(composeFile), false)
+	err = composeRunner.ComposeUp(context.Background(), "mystack", composeFile, overrideFile, filepath.Dir(composeFile))
 	if err != nil {
 		t.Fatalf("compose up failed: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestDinD_ComposeDown_RemovesContainers(t *testing.T) {
 	}
 	defer cleanup()
 
-	err = composeRunner.ComposeUp(context.Background(), "downstack", composeFile, overrideFile, filepath.Dir(composeFile), false)
+	err = composeRunner.ComposeUp(context.Background(), "downstack", composeFile, overrideFile, filepath.Dir(composeFile))
 	if err != nil {
 		t.Fatalf("compose up failed: %v", err)
 	}
@@ -366,7 +366,7 @@ func TestDinD_LabelRoundTrip(t *testing.T) {
 	defer cleanup()
 
 	composeRunner := reconcile.NewDockerComposeRunner(runner, env.DockerHost)
-	err = composeRunner.ComposeUp(context.Background(), "labelrt", composeFile, overrideFile, filepath.Dir(composeFile), false)
+	err = composeRunner.ComposeUp(context.Background(), "labelrt", composeFile, overrideFile, filepath.Dir(composeFile))
 	if err != nil {
 		t.Fatalf("compose up failed: %v", err)
 	}

--- a/backend/tests/integration/dind_compose_test.go
+++ b/backend/tests/integration/dind_compose_test.go
@@ -46,7 +46,11 @@ func TestDinD_ComposeUp_WritesFilesAndApplies(t *testing.T) {
 
 	waitForContainers(t, runner, 1, 15*time.Second)
 
-	client := docker.NewClient(runner, env.DockerHost)
+	sdkAPI, err := docker.NewSDKClient(env.DockerHost)
+	if err != nil {
+		t.Fatalf("SDK client: %v", err)
+	}
+	client := docker.NewClient(sdkAPI)
 	containers, err := client.ListContainersWithLabel(context.Background(), reconcile.LabelStackPath)
 	if err != nil {
 		t.Fatalf("ListContainersWithLabel failed: %v", err)
@@ -100,7 +104,11 @@ func TestDinD_ComposeDown_RemovesContainers(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
-	client := docker.NewClient(runner, env.DockerHost)
+	sdkAPI, err := docker.NewSDKClient(env.DockerHost)
+	if err != nil {
+		t.Fatalf("SDK client: %v", err)
+	}
+	client := docker.NewClient(sdkAPI)
 	containers, err := client.ListContainersWithLabel(context.Background(), reconcile.LabelStackPath)
 	if err != nil {
 		t.Fatalf("ListContainersWithLabel failed: %v", err)
@@ -115,7 +123,11 @@ func TestDinD_ComposeDown_RemovesContainers(t *testing.T) {
 func TestDinD_ListContainersWithLabel_RealDaemon(t *testing.T) {
 	env := dind.StartT(t)
 	runner := &dindRunner{Host: env.DockerHost}
-	client := docker.NewClient(runner, env.DockerHost)
+	sdkAPI, err := docker.NewSDKClient(env.DockerHost)
+	if err != nil {
+		t.Fatalf("SDK client: %v", err)
+	}
+	client := docker.NewClient(sdkAPI)
 
 	labelValue := "my/stack,path"
 	_, err := runner.Run(context.Background(), "docker", "run", "-d",
@@ -147,7 +159,11 @@ func TestDinD_ListContainersWithLabel_RealDaemon(t *testing.T) {
 func TestDinD_ListContainersWithLabel_MultipleContainers(t *testing.T) {
 	env := dind.StartT(t)
 	runner := &dindRunner{Host: env.DockerHost}
-	client := docker.NewClient(runner, env.DockerHost)
+	sdkAPI, err := docker.NewSDKClient(env.DockerHost)
+	if err != nil {
+		t.Fatalf("SDK client: %v", err)
+	}
+	client := docker.NewClient(sdkAPI)
 
 	for i := 0; i < 3; i++ {
 		_, err := runner.Run(context.Background(), "docker", "run", "-d",
@@ -174,7 +190,11 @@ func TestDinD_ListContainersWithLabel_MultipleContainers(t *testing.T) {
 func TestDinD_ListContainersWithLabel_NoMatch(t *testing.T) {
 	env := dind.StartT(t)
 	runner := &dindRunner{Host: env.DockerHost}
-	client := docker.NewClient(runner, env.DockerHost)
+	sdkAPI, err := docker.NewSDKClient(env.DockerHost)
+	if err != nil {
+		t.Fatalf("SDK client: %v", err)
+	}
+	client := docker.NewClient(sdkAPI)
 
 	containers, err := client.ListContainersWithLabel(context.Background(), "nonexistent.label")
 	if err != nil {
@@ -188,7 +208,11 @@ func TestDinD_ListContainersWithLabel_NoMatch(t *testing.T) {
 func TestDinD_ContainerCount_RealDaemon(t *testing.T) {
 	env := dind.StartT(t)
 	runner := &dindRunner{Host: env.DockerHost}
-	client := docker.NewClient(runner, env.DockerHost)
+	sdkAPI, err := docker.NewSDKClient(env.DockerHost)
+	if err != nil {
+		t.Fatalf("SDK client: %v", err)
+	}
+	client := docker.NewClient(sdkAPI)
 
 	status, err := client.ContainerCount(context.Background())
 	if err != nil {
@@ -234,7 +258,11 @@ func TestDinD_GetStackLabels_GroupsByStack(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
-	client := docker.NewClient(runner, env.DockerHost)
+	sdkAPI, err := docker.NewSDKClient(env.DockerHost)
+	if err != nil {
+		t.Fatalf("SDK client: %v", err)
+	}
+	client := docker.NewClient(sdkAPI)
 	inspector := reconcile.NewDockerContainerInspector(client)
 	labels, err := inspector.GetStackLabels(context.Background())
 	if err != nil {
@@ -272,7 +300,11 @@ func TestDinD_GetStackLabels_MultipleStacks(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 
-	client := docker.NewClient(runner, env.DockerHost)
+	sdkAPI, err := docker.NewSDKClient(env.DockerHost)
+	if err != nil {
+		t.Fatalf("SDK client: %v", err)
+	}
+	client := docker.NewClient(sdkAPI)
 	inspector := reconcile.NewDockerContainerInspector(client)
 	labels, err := inspector.GetStackLabels(context.Background())
 	if err != nil {
@@ -372,7 +404,11 @@ func TestDinD_LabelRoundTrip(t *testing.T) {
 	}
 	waitForContainers(t, runner, 1, 15*time.Second)
 
-	client := docker.NewClient(runner, env.DockerHost)
+	sdkAPI, err := docker.NewSDKClient(env.DockerHost)
+	if err != nil {
+		t.Fatalf("SDK client: %v", err)
+	}
+	client := docker.NewClient(sdkAPI)
 	containers, err := client.ListContainersWithLabel(context.Background(), reconcile.LabelStackPath)
 	if err != nil {
 		t.Fatalf("ListContainersWithLabel failed: %v", err)
@@ -416,7 +452,11 @@ func TestDinD_MapLabelsToMetadata_RealLabels(t *testing.T) {
 	})
 
 	composeRunner := reconcile.NewDockerComposeRunner(runner, env.DockerHost)
-	client := docker.NewClient(runner, env.DockerHost)
+	sdkAPI, err := docker.NewSDKClient(env.DockerHost)
+	if err != nil {
+		t.Fatalf("SDK client: %v", err)
+	}
+	client := docker.NewClient(sdkAPI)
 	inspector := reconcile.NewDockerContainerInspector(client)
 	r := newDindReconciler(store, reconcile.DefaultPolicy(), composeRunner, inspector, reconcile.NewAckStore(), "")
 

--- a/backend/tests/integration/dind_reconcile_test.go
+++ b/backend/tests/integration/dind_reconcile_test.go
@@ -66,7 +66,11 @@ func TestDinD_ReconcileComposeUp(t *testing.T) {
 	})
 
 	composeRunner := reconcile.NewDockerComposeRunner(runner, env.DockerHost)
-	client := docker.NewClient(runner, env.DockerHost)
+	sdkAPI, err := docker.NewSDKClient(env.DockerHost)
+	if err != nil {
+		t.Fatalf("SDK client: %v", err)
+	}
+	client := docker.NewClient(sdkAPI)
 	inspector := reconcile.NewDockerContainerInspector(client)
 
 	r := newDindReconciler(store, reconcile.DefaultPolicy(), composeRunner, inspector, reconcile.NewAckStore(), "")
@@ -140,7 +144,11 @@ func TestDinD_ReconcileBlockedUntilRefreshComplete(t *testing.T) {
 	})
 
 	composeRunner := reconcile.NewDockerComposeRunner(runner, env.DockerHost)
-	client := docker.NewClient(runner, env.DockerHost)
+	sdkAPI, err := docker.NewSDKClient(env.DockerHost)
+	if err != nil {
+		t.Fatalf("SDK client: %v", err)
+	}
+	client := docker.NewClient(sdkAPI)
 	inspector := reconcile.NewDockerContainerInspector(client)
 	r := newDindReconciler(store, reconcile.DefaultPolicy(), composeRunner, inspector, reconcile.NewAckStore(), "")
 
@@ -289,7 +297,11 @@ func TestDinD_ReconcileNoOpWhenInSync(t *testing.T) {
 	})
 
 	composeRunner := reconcile.NewDockerComposeRunner(runner, env.DockerHost)
-	client := docker.NewClient(runner, env.DockerHost)
+	sdkAPI, err := docker.NewSDKClient(env.DockerHost)
+	if err != nil {
+		t.Fatalf("SDK client: %v", err)
+	}
+	client := docker.NewClient(sdkAPI)
 	inspector := reconcile.NewDockerContainerInspector(client)
 	r := newDindReconciler(store, reconcile.DefaultPolicy(), composeRunner, inspector, reconcile.NewAckStore(), "")
 
@@ -333,7 +345,11 @@ func TestDinD_DriftDetectionRevisionChange(t *testing.T) {
 	})
 
 	composeRunner := reconcile.NewDockerComposeRunner(runner, env.DockerHost)
-	client := docker.NewClient(runner, env.DockerHost)
+	sdkAPI, err := docker.NewSDKClient(env.DockerHost)
+	if err != nil {
+		t.Fatalf("SDK client: %v", err)
+	}
+	client := docker.NewClient(sdkAPI)
 	inspector := reconcile.NewDockerContainerInspector(client)
 	r := newDindReconciler(store, reconcile.DefaultPolicy(), composeRunner, inspector, reconcile.NewAckStore(), "")
 
@@ -404,7 +420,11 @@ func TestDinD_StackRemoval(t *testing.T) {
 	})
 
 	composeRunner := reconcile.NewDockerComposeRunner(runner, env.DockerHost)
-	client := docker.NewClient(runner, env.DockerHost)
+	sdkAPI, err := docker.NewSDKClient(env.DockerHost)
+	if err != nil {
+		t.Fatalf("SDK client: %v", err)
+	}
+	client := docker.NewClient(sdkAPI)
 	inspector := reconcile.NewDockerContainerInspector(client)
 	policy := reconcile.DefaultPolicy()
 	policy.RemoveEnabled = true
@@ -465,7 +485,11 @@ func TestDinD_MultiServiceStack(t *testing.T) {
 	})
 
 	composeRunner := reconcile.NewDockerComposeRunner(runner, env.DockerHost)
-	client := docker.NewClient(runner, env.DockerHost)
+	sdkAPI, err := docker.NewSDKClient(env.DockerHost)
+	if err != nil {
+		t.Fatalf("SDK client: %v", err)
+	}
+	client := docker.NewClient(sdkAPI)
 	inspector := reconcile.NewDockerContainerInspector(client)
 	r := newDindReconciler(store, reconcile.DefaultPolicy(), composeRunner, inspector, reconcile.NewAckStore(), "")
 
@@ -515,7 +539,11 @@ func TestDinD_ComposeHashDrift(t *testing.T) {
 	})
 
 	composeRunner := reconcile.NewDockerComposeRunner(runner, env.DockerHost)
-	client := docker.NewClient(runner, env.DockerHost)
+	sdkAPI, err := docker.NewSDKClient(env.DockerHost)
+	if err != nil {
+		t.Fatalf("SDK client: %v", err)
+	}
+	client := docker.NewClient(sdkAPI)
 	inspector := reconcile.NewDockerContainerInspector(client)
 	r := newDindReconciler(store, reconcile.DefaultPolicy(), composeRunner, inspector, reconcile.NewAckStore(), "")
 
@@ -576,7 +604,11 @@ func TestDinD_FlagPolicyRequiresAck(t *testing.T) {
 	policy.DriftPolicy = "flag"
 
 	composeRunner := reconcile.NewDockerComposeRunner(runner, env.DockerHost)
-	client := docker.NewClient(runner, env.DockerHost)
+	sdkAPI, err := docker.NewSDKClient(env.DockerHost)
+	if err != nil {
+		t.Fatalf("SDK client: %v", err)
+	}
+	client := docker.NewClient(sdkAPI)
 	inspector := reconcile.NewDockerContainerInspector(client)
 	ackStore := reconcile.NewAckStore()
 	r := newDindReconciler(store, policy, composeRunner, inspector, ackStore, "")
@@ -626,7 +658,11 @@ func TestDinD_FourSpaceIndentLabels(t *testing.T) {
 	})
 
 	composeRunner := reconcile.NewDockerComposeRunner(runner, env.DockerHost)
-	client := docker.NewClient(runner, env.DockerHost)
+	sdkAPI, err := docker.NewSDKClient(env.DockerHost)
+	if err != nil {
+		t.Fatalf("SDK client: %v", err)
+	}
+	client := docker.NewClient(sdkAPI)
 	inspector := reconcile.NewDockerContainerInspector(client)
 	r := newDindReconciler(store, reconcile.DefaultPolicy(), composeRunner, inspector, reconcile.NewAckStore(), "")
 

--- a/backend/tests/integration/dind_update_test.go
+++ b/backend/tests/integration/dind_update_test.go
@@ -55,7 +55,11 @@ func TestDinD_UpdateCycleUsesLocalClone(t *testing.T) {
 		},
 	})
 
-	client := docker.NewClient(runner, env.DockerHost)
+	sdkAPI, err := docker.NewSDKClient(env.DockerHost)
+	if err != nil {
+		t.Fatalf("SDK client: %v", err)
+	}
+	client := docker.NewClient(sdkAPI)
 	composeRunner := reconcile.NewDockerComposeRunner(runner, env.DockerHost)
 	inspector := reconcile.NewDockerContainerInspector(client)
 	policy := reconcile.DefaultPolicy()
@@ -126,7 +130,11 @@ func TestDinD_UpdateCycleRestartsContainers(t *testing.T) {
 		}},
 	})
 
-	client := docker.NewClient(runner, env.DockerHost)
+	sdkAPI, err := docker.NewSDKClient(env.DockerHost)
+	if err != nil {
+		t.Fatalf("SDK client: %v", err)
+	}
+	client := docker.NewClient(sdkAPI)
 	composeRunner := reconcile.NewDockerComposeRunner(runner, env.DockerHost)
 	inspector := reconcile.NewDockerContainerInspector(client)
 	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug}))

--- a/backend/tests/integration/scheduler_test.go
+++ b/backend/tests/integration/scheduler_test.go
@@ -34,7 +34,7 @@ func TestSchedulerIntegration(t *testing.T) {
 	// Initialize dependencies
 	store := desiredstate.NewStore()
 	runner := &docker.ExecRunner{}
-	dockerClient := docker.NewClient(runner, cfg.DockerSocket)
+	dockerClient := docker.NewClient(nil)
 
 	// TODO: Setup test reconciler with proper dependencies
 	// This requires mocking or test containers
@@ -84,7 +84,7 @@ func TestSchedulerDisabled(t *testing.T) {
 
 	store := desiredstate.NewStore()
 	runner := &docker.ExecRunner{}
-	dockerClient := docker.NewClient(runner, cfg.DockerSocket)
+	dockerClient := docker.NewClient(nil)
 
 	schedulerSvc, err := scheduler.NewSchedulerService(cfg, logger, store, dockerClient, nil, nil)
 	if err != nil {
@@ -121,7 +121,7 @@ func TestCronExpressionValidation(t *testing.T) {
 
 			store := desiredstate.NewStore()
 			runner := &docker.ExecRunner{}
-			dockerClient := docker.NewClient(runner, cfg.DockerSocket)
+			dockerClient := docker.NewClient(nil)
 
 			schedulerSvc, err := scheduler.NewSchedulerService(cfg, logger, store, dockerClient, nil, nil)
 			if tt.shouldError && err == nil {
@@ -154,7 +154,7 @@ func TestSchedulerCustomSchedule(t *testing.T) {
 
 	store := desiredstate.NewStore()
 	runner := &docker.ExecRunner{}
-	dockerClient := docker.NewClient(runner, cfg.DockerSocket)
+	dockerClient := docker.NewClient(nil)
 
 	schedulerSvc, err := scheduler.NewSchedulerService(cfg, logger, store, dockerClient, nil, nil)
 	if err != nil {
@@ -189,7 +189,7 @@ func TestSchedulerLogging(t *testing.T) {
 
 	store := desiredstate.NewStore()
 	runner := &docker.ExecRunner{}
-	dockerClient := docker.NewClient(runner, cfg.DockerSocket)
+	dockerClient := docker.NewClient(nil)
 
 	schedulerSvc, err := scheduler.NewSchedulerService(cfg, logger, store, dockerClient, nil, nil)
 	if err != nil {

--- a/backend/tests/integration/scheduler_test.go
+++ b/backend/tests/integration/scheduler_test.go
@@ -33,7 +33,6 @@ func TestSchedulerIntegration(t *testing.T) {
 
 	// Initialize dependencies
 	store := desiredstate.NewStore()
-	runner := &docker.ExecRunner{}
 	dockerClient := docker.NewClient(nil)
 
 	// TODO: Setup test reconciler with proper dependencies
@@ -83,7 +82,6 @@ func TestSchedulerDisabled(t *testing.T) {
 	}
 
 	store := desiredstate.NewStore()
-	runner := &docker.ExecRunner{}
 	dockerClient := docker.NewClient(nil)
 
 	schedulerSvc, err := scheduler.NewSchedulerService(cfg, logger, store, dockerClient, nil, nil)
@@ -120,7 +118,6 @@ func TestCronExpressionValidation(t *testing.T) {
 			}
 
 			store := desiredstate.NewStore()
-			runner := &docker.ExecRunner{}
 			dockerClient := docker.NewClient(nil)
 
 			schedulerSvc, err := scheduler.NewSchedulerService(cfg, logger, store, dockerClient, nil, nil)
@@ -153,7 +150,6 @@ func TestSchedulerCustomSchedule(t *testing.T) {
 	}
 
 	store := desiredstate.NewStore()
-	runner := &docker.ExecRunner{}
 	dockerClient := docker.NewClient(nil)
 
 	schedulerSvc, err := scheduler.NewSchedulerService(cfg, logger, store, dockerClient, nil, nil)
@@ -188,7 +184,6 @@ func TestSchedulerLogging(t *testing.T) {
 	}
 
 	store := desiredstate.NewStore()
-	runner := &docker.ExecRunner{}
 	dockerClient := docker.NewClient(nil)
 
 	schedulerSvc, err := scheduler.NewSchedulerService(cfg, logger, store, dockerClient, nil, nil)

--- a/backend/tests/integration/smoke_test.go
+++ b/backend/tests/integration/smoke_test.go
@@ -41,7 +41,7 @@ func TestSmokeRootEndpoint(t *testing.T) {
 		DockerSocket: socketPath,
 	}
 
-	router := handler.NewRouter(runner, cfg, nil, nil, nil, nil, nil)
+	router := handler.NewRouter(cfg, nil, nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	w := httptest.NewRecorder()
@@ -88,7 +88,7 @@ func TestSmokeAPIEndpoints(t *testing.T) {
 	queue := refresh.NewQueue()
 	svc := refresh.NewService(cfg, store, queue, nil)
 
-	router := handler.NewRouter(runner, cfg, svc, store, nil, nil, nil)
+	router := handler.NewRouter(cfg, svc, store, nil, nil, nil, nil)
 
 	t.Run("POST /api/refresh returns 200", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/api/refresh", nil)

--- a/frontend/src/pages/StacksGrid.vue
+++ b/frontend/src/pages/StacksGrid.vue
@@ -104,6 +104,62 @@
             :show-indicator="false"
             style="margin-top: 8px"
           />
+
+          <!-- Image Pull Progress -->
+          <template v-if="store.pullProgress">
+            <div class="pull-progress-section">
+              <div class="pull-progress-header">
+                <n-text strong style="font-size: 12px">
+                  Pulling images for
+                  <n-text code style="font-size: 11px">{{ store.pullProgress.stack }}</n-text>
+                </n-text>
+                <n-tag size="tiny" type="info" round>
+                  {{ store.pullProgress.current }}/{{ store.pullProgress.total }}
+                </n-tag>
+              </div>
+              <div
+                v-for="img in store.pullProgress.images"
+                :key="img.image"
+                class="pull-image-row"
+              >
+                <span class="pull-image-done">
+                  <svg
+                    v-if="img.done"
+                    viewBox="0 0 16 16"
+                    width="13"
+                    height="13"
+                    fill="var(--success-color, #18a058)"
+                  >
+                    <path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.75.75 0 0 1 1.06-1.06L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0z" />
+                  </svg>
+                  <svg
+                    v-else
+                    viewBox="0 0 16 16"
+                    width="13"
+                    height="13"
+                    fill="var(--info-color, #2080f0)"
+                    style="animation: spin 1s linear infinite"
+                  >
+                    <path d="M8 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1zm0 1.5a5.5 5.5 0 1 1 0 11 5.5 5.5 0 0 1 0-11z" opacity=".3" />
+                    <path d="M8 1a7 7 0 0 1 7 7h-1.5A5.5 5.5 0 0 0 8 2.5V1z" />
+                  </svg>
+                </span>
+                <n-text code style="font-size: 11px; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap">
+                  {{ img.image }}
+                </n-text>
+                <n-text :depth="3" style="font-size: 11px; white-space: nowrap; margin-left: 6px">
+                  {{ img.done ? 'complete' : img.status }}
+                </n-text>
+                <n-text
+                  v-if="img.progress && !img.done"
+                  :depth="3"
+                  style="font-size: 10px; font-family: monospace; white-space: nowrap; margin-left: 6px; color: var(--info-color)"
+                >
+                  {{ img.progress }}
+                </n-text>
+              </div>
+            </div>
+          </template>
         </div>
         <n-button
           size="small"
@@ -419,5 +475,39 @@ function clearFilters() {
     flex-direction: column;
     align-items: stretch;
   }
+}
+
+.pull-progress-section {
+  margin-top: 10px;
+  border-top: 1px solid var(--border-color, rgba(128, 128, 128, 0.2));
+  padding-top: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.pull-progress-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.pull-image-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+
+.pull-image-done {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
 }
 </style>

--- a/frontend/src/store/stacks.ts
+++ b/frontend/src/store/stacks.ts
@@ -9,6 +9,20 @@ import { fetchRefreshStatus, fetchStacks } from '../services/api'
 import type { ConnectionState } from '../services/sse'
 import { SSEClient } from '../services/sse'
 
+export interface ImagePullStatus {
+  image: string
+  status: string
+  progress: string
+  done: boolean
+}
+
+export interface PullProgressState {
+  stack: string
+  images: ImagePullStatus[]
+  current: number
+  total: number
+}
+
 export const useStacksStore = defineStore('stacks', () => {
   // State
   const stackMap = ref<Map<string, StackRecord>>(new Map())
@@ -21,6 +35,7 @@ export const useStacksStore = defineStore('stacks', () => {
   // biome-ignore lint/suspicious/noExplicitAny: Progress type varies by event
   const updateProgress = ref<any>(null)
   const isUpdating = ref(false)
+  const pullProgress = ref<PullProgressState | null>(null)
 
   let sseClient: SSEClient | null = null
 
@@ -103,12 +118,49 @@ export const useStacksStore = defineStore('stacks', () => {
         updateProgress.value = progress
         if (progress.type === 'started') {
           isUpdating.value = true
-        } else if (progress.type === 'completed') {
-          isUpdating.value = false
-          // Clear progress after a short delay to show completion message
-          setTimeout(() => {
-            updateProgress.value = null
-          }, 3000)
+        } else if (progress.type === 'image_pull_progress') {
+          const isDone =
+            progress.status === 'Pull complete' ||
+            progress.status === 'Already exists' ||
+            progress.status === 'Download complete'
+
+          if (!pullProgress.value || pullProgress.value.stack !== progress.stack) {
+            pullProgress.value = {
+              stack: progress.stack,
+              images: [],
+              current: progress.current,
+              total: progress.total,
+            }
+          }
+
+          const existing = pullProgress.value.images.find((i) => i.image === progress.image)
+          if (existing) {
+            existing.status = progress.status
+            existing.progress = progress.progress ?? ''
+            existing.done = isDone
+          } else {
+            pullProgress.value.images.push({
+              image: progress.image,
+              status: progress.status,
+              progress: progress.progress ?? '',
+              done: isDone,
+            })
+          }
+          pullProgress.value.current = progress.current
+          pullProgress.value.total = progress.total
+        } else if (
+          progress.type === 'stack_success' ||
+          progress.type === 'stack_error' ||
+          progress.type === 'completed'
+        ) {
+          pullProgress.value = null
+          if (progress.type === 'completed') {
+            isUpdating.value = false
+            // Clear progress after a short delay to show completion message
+            setTimeout(() => {
+              updateProgress.value = null
+            }, 3000)
+          }
         }
       },
       onConnectionChange(state) {
@@ -147,6 +199,7 @@ export const useStacksStore = defineStore('stacks', () => {
     error,
     updateProgress,
     isUpdating,
+    pullProgress,
     // Getters
     stacks,
     filteredStacks,


### PR DESCRIPTION
## Summary

- **Migrate 5 Docker operations** (ContainerCount, ListContainersWithLabel, GetImageDigest, PruneImages, PullImages) from `exec.CommandContext` + `CombinedOutput()` to the Docker Go SDK (`github.com/docker/docker/client`)
- **Add streaming pull progress** via `PullProgressFn` callback, wired to SSE broadcaster as `image_pull_progress` events for real-time frontend updates
- **Replace `GetComposeImages` CLI call** with in-memory YAML parsing (`ExtractComposeImages`) — eliminates need for compose file on disk during update cycles
- **Remove `CommandRunner` from `docker.Client`** — the struct now holds only a `DockerAPI` interface, fully mockable for unit tests

## What stays on CLI

`ComposeUp`, `ComposeDown`, `ComposePs` remain CLI-based (`docker compose`) since the SDK has no compose-level equivalent without pulling in the full `docker/compose/v2` library (60+ deps including BuildKit).

## Testing

- All existing unit tests pass (updated mocks from `stubRunner` → `mockDockerAPI`)
- 12 new `ExtractComposeImages` tests, 5 new `PullImages` SDK tests
- Integration tests updated for new `NewClient(api)` signature
- `go test ./internal/... -race` clean

## Key files

| File | Change |
|------|--------|
| `internal/docker/sdk.go` | New — `DockerAPI` interface + `NewSDKClient()` constructor |
| `internal/docker/client.go` | `Client{API DockerAPI}`, SDK-based ContainerCount/ListContainersWithLabel |
| `internal/docker/images.go` | SDK-based GetImageDigest/PruneImages/PullImages with streaming |
| `internal/reconcile/compose.go` | Added `ExtractComposeImages()` YAML parser |
| `internal/scheduler/scheduler.go` | Wired `PullProgressFn` → SSE, uses `ExtractComposeImages` |
| `cmd/docker-cd/main.go` | Creates `NewSDKClient` + simplified wiring |