### PR TITLE
feat: show image pull progress during initial stack deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,13 @@ frontend/node_modules/
 frontend/dist/
 frontend/coverage/
 
+# E2E tests
+tests/e2e/node_modules/
+tests/e2e/test-results/
+
+# Node
+package-lock.json
+
 # Backend coverage
 backend/coverage.html
 backend/coverage.out
@@ -50,3 +57,6 @@ backend/coverage.out
 # Temporary
 *.tmp
 *.log
+
+# LEAD agent state
+.lead/state.json

--- a/.lead/_adhoc/reconcile-pull-progress.md
+++ b/.lead/_adhoc/reconcile-pull-progress.md
@@ -1,0 +1,125 @@
+# Reconcile Path: Image Pull Progress
+
+## TL;DR
+> **Summary**: Add an explicit image pull step with SSE progress reporting to `syncStack()` so initial stack deployments show per-image pull progress, reusing the existing `PullImages`/`image_pull_progress` infrastructure.
+> **Estimated Effort**: Short
+
+## Context
+### Original Request
+When a stack is first deployed via `syncStack()` in the reconcile path, `ComposeUp()` pulls images implicitly with no progress feedback. The scheduler's `updateStack()` already has explicit pulls with SSE progress — we need the same for reconciliation.
+
+### Key Findings
+- `Reconciler` struct has no `docker.Client` or image-pulling capability — it only has `ComposeRunner` and `ContainerInspector` interfaces.
+- The scheduler wires `PullProgressFn` → `broadcaster.PublishUpdateProgress()` with `type: "image_pull_progress"`, including `stack`, `image`, `status`, `progress`, `current`, `total`.
+- The frontend `stacks.ts` store already handles `image_pull_progress` events and populates `pullProgress` state — no frontend changes needed if we emit the same event shape.
+- `reconcile.ExtractComposeImages(content []byte)` already exists and is used by the scheduler.
+- `NewReconciler()` is called in `main.go:121` and in ~20 test call sites — the signature change must be backward-compatible or all tests updated.
+- The `Broadcaster` is available in `main.go` and could be passed to the reconciler.
+
+## Objectives
+### Core Objective
+Show per-image pull progress during reconcile-path deployments using the existing SSE infrastructure.
+
+### Deliverables
+- `ImagePuller` interface in `reconcile` package
+- `Reconciler` accepts an optional `ImagePuller` + `Broadcaster`
+- `syncStack()` pulls images before `ComposeUp()` with progress callbacks
+- All existing tests compile and pass
+
+### Definition of Done
+- `go build ./...` succeeds
+- `go test ./internal/reconcile/...` passes
+- `go test ./...` passes
+- Manual test: deploy a new stack, observe `image_pull_progress` events in browser SSE stream
+
+### Guardrails (Must NOT)
+- Must not break the scheduler's existing pull progress path
+- Must not import `docker` package into `reconcile` — use an interface
+- Must not require frontend changes (reuse exact same SSE event shape)
+- Must not block reconciliation if puller is nil (graceful fallback to implicit pull)
+
+## Progress
+
+- [x] 1. Define ImagePuller interface
+- [x] 2. Add ImagePuller and Broadcaster to Reconciler
+- [x] 3. Wire image pull into syncStack()
+- [x] 4. Pass dependencies in main.go
+- [x] 5. Update tests
+- [x] All tests pass
+- [x] No regressions
+
+## TODOs
+
+### 1. Define ImagePuller interface
+**What**: Add a minimal `ImagePuller` interface to `reconcile/reconcile.go` that wraps only what `syncStack()` needs. Reuse `docker.PullProgress` and `docker.PullProgressFn` types by defining local aliases or a local callback type to avoid importing the `docker` package.
+**Files**: `backend/internal/reconcile/reconcile.go`
+**Acceptance**: Interface compiles; `go build ./internal/reconcile/...` succeeds
+
+```go
+// PullProgress mirrors docker.PullProgress for decoupling.
+type PullProgress struct {
+    Image    string
+    Status   string
+    Progress string
+    Current  int
+    Total    int
+}
+
+// PullProgressFn is called with pull progress updates.
+type PullProgressFn func(PullProgress)
+
+// ImagePuller pulls container images with progress reporting.
+type ImagePuller interface {
+    PullImages(ctx context.Context, images []string, onProgress PullProgressFn) error
+}
+```
+
+### 2. Add ImagePuller and Broadcaster to Reconciler
+**What**: Add `imagePuller ImagePuller` and `broadcaster *desiredstate.Broadcaster` fields to `Reconciler`. Add them as **optional** parameters to `NewReconciler()`. Since there are ~20 test call sites, use a functional options pattern or simply add the two new params at the end (both can be nil). Recommendation: add to the end of the parameter list since all call sites are explicit — a simple find/replace adds `, nil, nil` to tests.
+**Files**: `backend/internal/reconcile/reconcile.go`
+**Acceptance**: `go build ./internal/reconcile/...` succeeds with nil values
+
+### 3. Wire image pull into syncStack()
+**What**: In `syncStack()`, after writing temp compose files and before calling `ComposeUp()`:
+1. Extract images via `ExtractComposeImages(stack.Content)`
+2. If `r.imagePuller != nil` and images are non-empty, build a `PullProgressFn` that publishes `image_pull_progress` events via `r.broadcaster.PublishUpdateProgress()` using the exact same map shape as `scheduler.go:356-368` (but without `cycle_id` — use empty string or omit)
+3. Call `r.imagePuller.PullImages(ctx, images, onProgress)`
+4. If pull fails, mark stack as failed and return early
+5. If `r.imagePuller` is nil, skip — `ComposeUp()` will pull implicitly (existing behavior)
+**Files**: `backend/internal/reconcile/reconcile.go`
+**Acceptance**: `go build ./...` succeeds; logic is correct by code review
+
+### 4. Pass dependencies in main.go
+**What**: In `main.go`, create an adapter that wraps `docker.Client` to satisfy `reconcile.ImagePuller`. The adapter converts `docker.PullProgress` → `reconcile.PullProgress`. Pass the adapter and `broadcaster` to `NewReconciler()`.
+**Files**: `backend/cmd/docker-cd/main.go`
+**Acceptance**: `go build ./cmd/docker-cd/...` succeeds
+
+Adapter approach (can live in `main.go` or a small file):
+```go
+type dockerImagePuller struct {
+    client *docker.Client
+}
+
+func (d *dockerImagePuller) PullImages(ctx context.Context, images []string, onProgress reconcile.PullProgressFn) error {
+    var dockerProgress docker.PullProgressFn
+    if onProgress != nil {
+        dockerProgress = func(p docker.PullProgress) {
+            onProgress(reconcile.PullProgress{
+                Image: p.Image, Status: p.Status, Progress: p.Progress,
+                Current: p.Current, Total: p.Total,
+            })
+        }
+    }
+    return d.client.PullImages(ctx, images, dockerProgress)
+}
+```
+
+### 5. Update tests
+**What**: Update all `NewReconciler()` call sites in test files to pass `nil, nil` for the two new parameters. Optionally add one test in `reconcile_test.go` that verifies `syncStack()` calls `ImagePuller.PullImages` when provided.
+**Files**: `backend/internal/reconcile/reconcile_test.go`, `backend/internal/scheduler/scheduler_test.go`, `backend/tests/integration/dind_reconcile_test.go`
+**Acceptance**: `go test ./...` passes
+
+### Verification
+- All tests pass: `go test ./...`
+- No regressions: scheduler pull progress still works (same SSE event shape, different origin)
+- Manual: deploy a stack that needs image pulls, confirm `image_pull_progress` events appear in browser DevTools SSE stream

--- a/backend/cmd/docker-cd/main.go
+++ b/backend/cmd/docker-cd/main.go
@@ -118,7 +118,7 @@ func main() {
 	driftDetector := reconcile.NewDriftDetector(cfg.GitDeployDir, logger)
 	stateManager := reconcile.NewStateManager(store, composeRunner, eventBus, logger)
 
-	reconciler := reconcile.NewReconciler(store, policy, composeRunner, inspector, ackStore, cfg.GitDeployDir, driftDetector, stateManager, logger)
+	reconciler := reconcile.NewReconciler(store, policy, composeRunner, inspector, ackStore, cfg.GitDeployDir, driftDetector, stateManager, logger, &dockerImagePuller{client: dockerClient}, broadcaster)
 
 	// Wire reconciler into refresh pipeline
 	refreshSvc.SetReconcileFunc(func(ctx context.Context) {
@@ -256,4 +256,25 @@ func setupEventHandlers(eventBus *events.EventBus, broadcaster *desiredstate.Bro
 		}
 		return nil
 	})
+}
+
+// dockerImagePuller adapts docker.Client to reconcile.ImagePuller.
+type dockerImagePuller struct {
+	client *docker.Client
+}
+
+func (d *dockerImagePuller) PullImages(ctx context.Context, images []string, onProgress reconcile.PullProgressFn) error {
+	var dockerProgress docker.PullProgressFn
+	if onProgress != nil {
+		dockerProgress = func(p docker.PullProgress) {
+			onProgress(reconcile.PullProgress{
+				Image:    p.Image,
+				Status:   p.Status,
+				Progress: p.Progress,
+				Current:  p.Current,
+				Total:    p.Total,
+			})
+		}
+	}
+	return d.client.PullImages(ctx, images, dockerProgress)
 }

--- a/backend/internal/reconcile/reconcile.go
+++ b/backend/internal/reconcile/reconcile.go
@@ -22,6 +22,23 @@ type ComposeRunner interface {
 	ComposePs(ctx context.Context, projectName string) ([]desiredstate.ContainerInfo, error)
 }
 
+// PullProgress reports per-image pull status.
+type PullProgress struct {
+	Image    string
+	Status   string
+	Progress string
+	Current  int
+	Total    int
+}
+
+// PullProgressFn is called with pull progress updates.
+type PullProgressFn func(PullProgress)
+
+// ImagePuller pulls container images with progress reporting.
+type ImagePuller interface {
+	PullImages(ctx context.Context, images []string, onProgress PullProgressFn) error
+}
+
 // ContainerInspector reads runtime container labels.
 type ContainerInspector interface {
 	// GetStackLabels returns sync metadata labels grouped by stack path.
@@ -64,6 +81,8 @@ type Reconciler struct {
 	deployDir     string
 	driftDetector *DriftDetector
 	stateManager  *StateManager
+	imagePuller   ImagePuller
+	broadcaster   *desiredstate.Broadcaster
 	logger        *slog.Logger
 }
 
@@ -78,6 +97,8 @@ func NewReconciler(
 	driftDetector *DriftDetector,
 	stateManager *StateManager,
 	logger *slog.Logger,
+	imagePuller ImagePuller,
+	broadcaster *desiredstate.Broadcaster,
 ) *Reconciler {
 	return &Reconciler{
 		store:         store,
@@ -88,6 +109,8 @@ func NewReconciler(
 		deployDir:     deployDir,
 		driftDetector: driftDetector,
 		stateManager:  stateManager,
+		imagePuller:   imagePuller,
+		broadcaster:   broadcaster,
 		logger:        logger,
 	}
 }
@@ -283,6 +306,37 @@ func (r *Reconciler) syncStack(ctx context.Context, drift DriftResult, snap *des
 		return run
 	}
 	defer cleanup()
+
+	// Explicitly pull images with progress reporting before compose up.
+	// When imagePuller is nil, ComposeUp will pull images implicitly (no progress).
+	if r.imagePuller != nil {
+		images := ExtractComposeImages(stack.Content)
+		if len(images) > 0 {
+			var onProgress PullProgressFn
+			if r.broadcaster != nil {
+				onProgress = func(p PullProgress) {
+					r.broadcaster.PublishUpdateProgress(map[string]interface{}{
+						"type":      "image_pull_progress",
+						"stack":     drift.Path,
+						"image":     p.Image,
+						"status":    p.Status,
+						"progress":  p.Progress,
+						"current":   p.Current,
+						"total":     p.Total,
+						"timestamp": time.Now(),
+					})
+				}
+			}
+			if err := r.imagePuller.PullImages(ctx, images, onProgress); err != nil {
+				run.Result = "failed"
+				run.Error = fmt.Sprintf("image pull failed: %v", err)
+				run.FinishedAt = time.Now()
+				r.logger.Error("image pull failed", "stack_path", drift.Path, "error", err)
+				r.stateManager.UpdateStatus(drift.Path, desiredstate.StackSyncFailed, "", truncateError(run.Error))
+				return run
+			}
+		}
+	}
 
 	// Run docker compose up
 	// workDir is set to the stack path so Docker Compose resolves relative

--- a/backend/internal/reconcile/reconcile_test.go
+++ b/backend/internal/reconcile/reconcile_test.go
@@ -253,7 +253,7 @@ func TestReconcile_DriftedStack_Synced(t *testing.T) {
 	compose := &stubComposeRunner{}
 	inspector := &stubInspector{labels: map[string]reconcile.StackSyncMetadata{}}
 
-	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default())
+	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default(), nil, nil)
 	runs := r.Reconcile(context.Background())
 
 	if len(runs) != 1 {
@@ -302,7 +302,7 @@ func TestReconcile_AlreadySynced_NoOp(t *testing.T) {
 		},
 	}
 
-	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default())
+	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default(), nil, nil)
 	runs := r.Reconcile(context.Background())
 
 	if len(runs) != 0 {
@@ -326,7 +326,7 @@ func TestReconcile_Disabled(t *testing.T) {
 	compose := &stubComposeRunner{}
 	inspector := &stubInspector{labels: map[string]reconcile.StackSyncMetadata{}}
 
-	r := reconcile.NewReconciler(store, policy, compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default())
+	r := reconcile.NewReconciler(store, policy, compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default(), nil, nil)
 	runs := r.Reconcile(context.Background())
 
 	if runs != nil {
@@ -348,7 +348,7 @@ func TestReconcile_ComposeUpFailure(t *testing.T) {
 	compose := &stubComposeRunner{upErr: fmt.Errorf("image not found")}
 	inspector := &stubInspector{labels: map[string]reconcile.StackSyncMetadata{}}
 
-	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default())
+	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default(), nil, nil)
 	runs := r.Reconcile(context.Background())
 
 	if len(runs) != 1 {
@@ -393,7 +393,7 @@ func TestReconcile_DriftPolicy_Flag_NoAck(t *testing.T) {
 	compose := &stubComposeRunner{}
 	inspector := &stubInspector{labels: map[string]reconcile.StackSyncMetadata{}}
 
-	r := reconcile.NewReconciler(store, policy, compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default())
+	r := reconcile.NewReconciler(store, policy, compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default(), nil, nil)
 	runs := r.Reconcile(context.Background())
 
 	// No runs should execute without acknowledgement
@@ -424,7 +424,7 @@ func TestReconcile_DriftPolicy_Flag_WithAck(t *testing.T) {
 	ackStore := reconcile.NewAckStore()
 	ackStore.Acknowledge("app1")
 
-	r := reconcile.NewReconciler(store, policy, compose, inspector, ackStore, "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default())
+	r := reconcile.NewReconciler(store, policy, compose, inspector, ackStore, "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default(), nil, nil)
 	runs := r.Reconcile(context.Background())
 
 	if len(runs) != 1 {
@@ -454,7 +454,7 @@ func TestReconcile_DriftPolicy_Revert(t *testing.T) {
 	compose := &stubComposeRunner{}
 	inspector := &stubInspector{labels: map[string]reconcile.StackSyncMetadata{}}
 
-	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default())
+	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default(), nil, nil)
 	runs := r.Reconcile(context.Background())
 
 	// Revert mode should auto-reconcile without ack
@@ -483,7 +483,7 @@ func TestReconcile_ConcurrencyMutex(t *testing.T) {
 	// Inspector that updates after first sync (simulating containers getting labels)
 	inspector := &dynamicInspector{}
 
-	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default())
+	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default(), nil, nil)
 
 	// Run reconcile — first should sync
 	runs1 := r.Reconcile(context.Background())
@@ -519,7 +519,7 @@ func TestReconcile_CachePreservedOnFailure(t *testing.T) {
 	compose := &stubComposeRunner{upErr: fmt.Errorf("deploy failed")}
 	inspector := &stubInspector{labels: map[string]reconcile.StackSyncMetadata{}}
 
-	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default())
+	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default(), nil, nil)
 	r.Reconcile(context.Background())
 
 	// Desired state cache should be intact
@@ -572,7 +572,7 @@ func TestReconciliationRun_Timestamps(t *testing.T) {
 	inspector := &stubInspector{labels: map[string]reconcile.StackSyncMetadata{}}
 
 	before := time.Now()
-	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default())
+	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default(), nil, nil)
 	runs := r.Reconcile(context.Background())
 	after := time.Now()
 
@@ -605,7 +605,7 @@ func TestReconcile_MultipleStacks_Sequential(t *testing.T) {
 	compose := &stubComposeRunner{}
 	inspector := &stubInspector{labels: map[string]reconcile.StackSyncMetadata{}}
 
-	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default())
+	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default(), nil, nil)
 	runs := r.Reconcile(context.Background())
 
 	if len(runs) != 3 {
@@ -643,7 +643,7 @@ func TestReconcile_RemoveStack(t *testing.T) {
 		},
 	}
 
-	r := reconcile.NewReconciler(store, policy, compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default())
+	r := reconcile.NewReconciler(store, policy, compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default(), nil, nil)
 	runs := r.Reconcile(context.Background())
 
 	if len(runs) != 1 {
@@ -674,7 +674,7 @@ func TestReconcile_RemoveDisabled_Skips(t *testing.T) {
 		},
 	}
 
-	r := reconcile.NewReconciler(store, policy, compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default())
+	r := reconcile.NewReconciler(store, policy, compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default(), nil, nil)
 	runs := r.Reconcile(context.Background())
 
 	if len(runs) != 0 {
@@ -702,7 +702,7 @@ func TestReconcileStack_Success(t *testing.T) {
 	compose := &stubComposeRunner{}
 	inspector := &stubInspector{labels: map[string]reconcile.StackSyncMetadata{}}
 
-	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default())
+	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default(), nil, nil)
 	run := r.ReconcileStack(context.Background(), "app1")
 
 	if run.Result != "success" {
@@ -729,7 +729,7 @@ func TestReconcileStack_NilSnapshot(t *testing.T) {
 	compose := &stubComposeRunner{}
 	inspector := &stubInspector{labels: map[string]reconcile.StackSyncMetadata{}}
 
-	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default())
+	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default(), nil, nil)
 	run := r.ReconcileStack(context.Background(), "app1")
 
 	if run.Result != "failed" {
@@ -757,7 +757,7 @@ func TestReconcileStack_StackNotFound(t *testing.T) {
 	compose := &stubComposeRunner{}
 	inspector := &stubInspector{labels: map[string]reconcile.StackSyncMetadata{}}
 
-	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default())
+	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default(), nil, nil)
 	run := r.ReconcileStack(context.Background(), "nonexistent-stack")
 
 	if run.Result != "failed" {
@@ -785,7 +785,7 @@ func TestReconcileStack_ComposeUpFailure(t *testing.T) {
 	compose := &stubComposeRunner{upErr: fmt.Errorf("connection refused")}
 	inspector := &stubInspector{labels: map[string]reconcile.StackSyncMetadata{}}
 
-	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default())
+	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default(), nil, nil)
 	run := r.ReconcileStack(context.Background(), "app1")
 
 	if run.Result != "failed" {
@@ -822,7 +822,7 @@ func TestReconcileStack_BypassesDriftDetection(t *testing.T) {
 		},
 	}
 
-	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default())
+	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default(), nil, nil)
 
 	// Verify Reconcile() would skip this stack (it's in sync)
 	runs := r.Reconcile(context.Background())
@@ -866,7 +866,7 @@ func TestReconcile_NoOp_MultipleStacksInSync(t *testing.T) {
 		},
 	}
 
-	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default())
+	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default(), nil, nil)
 	runs := r.Reconcile(context.Background())
 
 	if len(runs) != 0 {
@@ -912,7 +912,7 @@ func TestCancelActive_CancelsRunningReconcile(t *testing.T) {
 	compose := &blockingComposeRunner{upStarted: make(chan struct{})}
 	inspector := &stubInspector{labels: map[string]reconcile.StackSyncMetadata{}}
 	sm := newTestStateManager(store, compose)
-	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), sm, slog.Default())
+	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), sm, slog.Default(), nil, nil)
 
 	done := make(chan []reconcile.ReconciliationRun, 1)
 	go func() {
@@ -948,8 +948,119 @@ func TestCancelActive_SafeWhenNoReconcileActive(t *testing.T) {
 	compose := &stubComposeRunner{}
 	inspector := &stubInspector{labels: map[string]reconcile.StackSyncMetadata{}}
 	sm := newTestStateManager(store, compose)
-	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), sm, slog.Default())
+	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), sm, slog.Default(), nil, nil)
 
 	// Should not panic
 	r.CancelActive()
+}
+
+// --- ImagePuller tests ---
+
+type stubImagePuller struct {
+	pullCalls [][]string
+	pullErr   error
+}
+
+func (s *stubImagePuller) PullImages(_ context.Context, images []string, onProgress reconcile.PullProgressFn) error {
+	s.pullCalls = append(s.pullCalls, images)
+	if onProgress != nil {
+		for i, img := range images {
+			onProgress(reconcile.PullProgress{Image: img, Status: "Pull complete", Current: i + 1, Total: len(images)})
+		}
+	}
+	return s.pullErr
+}
+
+func TestReconcile_WithImagePuller_PullsBeforeComposeUp(t *testing.T) {
+	store := desiredstate.NewStore()
+	composeContent := []byte("services:\n  web:\n    image: nginx:alpine\n")
+	store.Set(&desiredstate.Snapshot{
+		Revision:      "rev1",
+		CommitMessage: "deploy",
+		RefreshStatus: desiredstate.RefreshStatusCompleted,
+		Stacks: []desiredstate.StackRecord{
+			{Path: "app1", ComposeFile: "docker-compose.yml", ComposeHash: "h1", Status: desiredstate.StackSyncMissing, Content: composeContent},
+		},
+	})
+
+	compose := &stubComposeRunner{}
+	inspector := &stubInspector{labels: map[string]reconcile.StackSyncMetadata{}}
+	puller := &stubImagePuller{}
+
+	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default(), puller, nil)
+	runs := r.Reconcile(context.Background())
+
+	if len(runs) != 1 || runs[0].Result != "success" {
+		t.Fatalf("expected 1 successful run, got %d runs, result=%q error=%q", len(runs), runs[0].Result, runs[0].Error)
+	}
+	if len(puller.pullCalls) != 1 {
+		t.Fatalf("expected 1 pull call, got %d", len(puller.pullCalls))
+	}
+	if len(puller.pullCalls[0]) != 1 || puller.pullCalls[0][0] != "nginx:alpine" {
+		t.Errorf("expected pull of [nginx:alpine], got %v", puller.pullCalls[0])
+	}
+	if len(compose.upCalls) != 1 {
+		t.Errorf("expected 1 compose up call, got %d", len(compose.upCalls))
+	}
+}
+
+func TestReconcile_ImagePullFailure_StackFailed(t *testing.T) {
+	store := desiredstate.NewStore()
+	composeContent := []byte("services:\n  web:\n    image: nginx:alpine\n")
+	store.Set(&desiredstate.Snapshot{
+		Revision:      "rev1",
+		CommitMessage: "deploy",
+		RefreshStatus: desiredstate.RefreshStatusCompleted,
+		Stacks: []desiredstate.StackRecord{
+			{Path: "app1", ComposeFile: "docker-compose.yml", ComposeHash: "h1", Status: desiredstate.StackSyncMissing, Content: composeContent},
+		},
+	})
+
+	compose := &stubComposeRunner{}
+	inspector := &stubInspector{labels: map[string]reconcile.StackSyncMetadata{}}
+	puller := &stubImagePuller{pullErr: fmt.Errorf("unauthorized")}
+
+	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default(), puller, nil)
+	runs := r.Reconcile(context.Background())
+
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 run, got %d", len(runs))
+	}
+	if runs[0].Result != "failed" {
+		t.Errorf("expected failed, got %q", runs[0].Result)
+	}
+	if runs[0].Error != "image pull failed: unauthorized" {
+		t.Errorf("unexpected error: %q", runs[0].Error)
+	}
+	// ComposeUp should NOT have been called
+	if len(compose.upCalls) != 0 {
+		t.Errorf("expected 0 compose up calls after pull failure, got %d", len(compose.upCalls))
+	}
+}
+
+func TestReconcile_NilImagePuller_SkipsPull(t *testing.T) {
+	store := desiredstate.NewStore()
+	composeContent := []byte("services:\n  web:\n    image: nginx:alpine\n")
+	store.Set(&desiredstate.Snapshot{
+		Revision:      "rev1",
+		CommitMessage: "deploy",
+		RefreshStatus: desiredstate.RefreshStatusCompleted,
+		Stacks: []desiredstate.StackRecord{
+			{Path: "app1", ComposeFile: "docker-compose.yml", ComposeHash: "h1", Status: desiredstate.StackSyncMissing, Content: composeContent},
+		},
+	})
+
+	compose := &stubComposeRunner{}
+	inspector := &stubInspector{labels: map[string]reconcile.StackSyncMetadata{}}
+
+	// nil puller — should fall through to ComposeUp (implicit pull)
+	r := reconcile.NewReconciler(store, reconcile.DefaultPolicy(), compose, inspector, reconcile.NewAckStore(), "", newTestDriftDetector(""), newTestStateManager(store, compose), slog.Default(), nil, nil)
+	runs := r.Reconcile(context.Background())
+
+	if len(runs) != 1 || runs[0].Result != "success" {
+		t.Fatalf("expected success, got result=%q", runs[0].Result)
+	}
+	if len(compose.upCalls) != 1 {
+		t.Errorf("expected 1 compose up call, got %d", len(compose.upCalls))
+	}
 }

--- a/backend/internal/scheduler/scheduler_test.go
+++ b/backend/internal/scheduler/scheduler_test.go
@@ -174,6 +174,7 @@ func newTestReconciler(store *desiredstate.Store) *reconcile.Reconciler {
 		nil, // driftDetector — not needed for ReconcileStack path
 		sm,
 		slog.Default(),
+		nil, nil,
 	)
 }
 

--- a/backend/tests/integration/dind_reconcile_test.go
+++ b/backend/tests/integration/dind_reconcile_test.go
@@ -718,6 +718,7 @@ func newDindReconciler(
 		reconcile.NewDriftDetector("", logger),
 		reconcile.NewStateManager(store, composeRunner, nil, logger),
 		logger,
+		nil, nil,
 	)
 }
 


### PR DESCRIPTION
## Summary
- Add explicit image pulling with SSE progress reporting to the **reconcile path**, so initial stack deployments show per-image pull progress in the frontend (previously only shown during scheduled update cycles)
- Define `ImagePuller` interface in `reconcile` package with dependency inversion (no `docker` import) and `dockerImagePuller` adapter in `main.go`
- Both `imagePuller` and `broadcaster` are nil-safe — when nil, existing behavior (implicit pull via `docker compose up`) is preserved

## Changes
- `reconcile.go`: `ImagePuller` interface, `PullProgress`/`PullProgressFn` types, explicit pull step in `syncStack()` before `ComposeUp()`, emits `image_pull_progress` SSE events (same shape as scheduler path — zero frontend changes needed)
- `main.go`: `dockerImagePuller` adapter bridging `docker.Client` → `reconcile.ImagePuller`
- 3 new unit tests: pull success, pull failure (verifies `ComposeUp` not called), nil-puller fallback
- `.gitignore`: added `tests/e2e/node_modules/`, `tests/e2e/test-results/`, `package-lock.json`, `.lead/state.json`